### PR TITLE
Enhance error messages when accessing qubit and registers

### DIFF
--- a/examples/generator/mock_to_qir.py
+++ b/examples/generator/mock_to_qir.py
@@ -27,7 +27,8 @@ class QirGenerator(MockLanguageListener):
         self.builder = QirBuilder(module_id)
         self.builder.add_quantum_register("q", nr_qubits)
         self.builder.add_classical_register("m", nr_qubits)
-        
+        self.nr_qubits = nr_qubits
+
     @property
     def ir_string(self) -> str:
         return self.builder.get_ir_string()
@@ -40,15 +41,27 @@ class QirGenerator(MockLanguageListener):
             file.write(self.ir_string)
 
     def enterXGate(self, ctx: MockLanguageParser.XGateContext):
+        if int(ctx.target.text) >= self.nr_qubits:
+            raise ValueError("Parsed progam uses more qubits than allocated")
+
         self.builder.x("q" + ctx.target.text)
 
-    def enterHGate(self, ctx:MockLanguageParser.HGateContext):
+    def enterHGate(self, ctx: MockLanguageParser.HGateContext):
+        if int(ctx.target.text) >= self.nr_qubits:
+            raise ValueError("Parsed progam uses more qubits than allocated")
+
         self.builder.h("q" + ctx.target.text)
 
-    def enterCNOTGate(self, ctx:MockLanguageParser.CNOTGateContext):
+    def enterCNOTGate(self, ctx: MockLanguageParser.CNOTGateContext):
+        if int(ctx.target.text) >= self.nr_qubits:
+            raise ValueError("Parsed progam uses more qubits than allocated")
+
         self.builder.cx("q" + ctx.control.text, "q" + ctx.target.text)
 
-    def enterMzGate(self, ctx:MockLanguageParser.MzGateContext):
+    def enterMzGate(self, ctx: MockLanguageParser.MzGateContext):
+        if int(ctx.target.text) >= self.nr_qubits:
+            raise ValueError("Parsed progam uses more qubits than allocated")
+
         self.builder.m("q" + ctx.target.text, "m" + ctx.target.text)
 
 

--- a/examples/generator/mock_to_qir.py
+++ b/examples/generator/mock_to_qir.py
@@ -17,8 +17,8 @@ class QirGenerator(MockLanguageListener):
     """
     Class that generates QIR when walking the parse tree 
     of a Mock language program.
-    """    
-    
+    """
+
     def __init__(self, nr_qubits: int, module_id: str):
         """
         :param nr_qubits: The total number of qubits used in the compilation.
@@ -80,7 +80,7 @@ def mock_program_to_qir(nr_qubits: int, input_file: str) -> str:
     stream = CommonTokenStream(lexer)
     parser = MockLanguageParser(stream)
     tree = parser.document()
-    
+
     generator = QirGenerator(nr_qubits, Path(input_file).stem)
     walker = ParseTreeWalker()
     walker.walk(generator, tree)
@@ -106,5 +106,5 @@ if __name__ == '__main__':
     if args.output_file is not None:
         with open(args.output_file, 'w') as file:
             file.write(generated_qir)
-    else: print(generated_qir)
-
+    else:
+        print(generated_qir)

--- a/examples/generator/mock_to_qir.py
+++ b/examples/generator/mock_to_qir.py
@@ -41,28 +41,26 @@ class QirGenerator(MockLanguageListener):
             file.write(self.ir_string)
 
     def enterXGate(self, ctx: MockLanguageParser.XGateContext):
-        if int(ctx.target.text) >= self.nr_qubits:
-            raise ValueError("Parsed progam uses more qubits than allocated")
-
+        self.verify_qubit_in_range(ctx.target.text)
         self.builder.x("q" + ctx.target.text)
 
     def enterHGate(self, ctx: MockLanguageParser.HGateContext):
-        if int(ctx.target.text) >= self.nr_qubits:
-            raise ValueError("Parsed progam uses more qubits than allocated")
-
+        self.verify_qubit_in_range(ctx.target.text)
         self.builder.h("q" + ctx.target.text)
 
     def enterCNOTGate(self, ctx: MockLanguageParser.CNOTGateContext):
-        if int(ctx.target.text) >= self.nr_qubits:
-            raise ValueError("Parsed progam uses more qubits than allocated")
+        self.verify_qubit_in_range(ctx.control.text)
+        self.verify_qubit_in_range(ctx.target.text)
 
         self.builder.cx("q" + ctx.control.text, "q" + ctx.target.text)
 
     def enterMzGate(self, ctx: MockLanguageParser.MzGateContext):
-        if int(ctx.target.text) >= self.nr_qubits:
-            raise ValueError("Parsed progam uses more qubits than allocated")
-
+        self.verify_qubit_in_range(ctx.target.text)
         self.builder.m("q" + ctx.target.text, "m" + ctx.target.text)
+
+    def verify_qubit_in_range(self, text):
+        if int(text) >= self.nr_qubits:
+            raise ValueError("Parsed progam uses more qubits than allocated")
 
 
 def mock_program_to_qir(nr_qubits: int, input_file: str) -> str:

--- a/pyqir-generator/src/qir/instructions.rs
+++ b/pyqir-generator/src/qir/instructions.rs
@@ -8,7 +8,7 @@ use super::{
     basic_values, calls,
 };
 use qirlib::context::Context;
-use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, FunctionValue};
+use inkwell::values::{BasicValueEnum, FunctionValue};
 use std::collections::HashMap;
 
 /// # Panics
@@ -18,7 +18,7 @@ fn get_qubit<'ctx>(
     name: &String,
     qubits: &HashMap<String, BasicValueEnum<'ctx>>,
 ) -> BasicValueEnum<'ctx> {
-    qubits.get(name).unwrap().to_owned()
+    qubits.get(name).expect(format!("Qubit {} not found.", name).as_str()).to_owned()
 }
 
 /// # Panics
@@ -28,7 +28,7 @@ fn get_register<'ctx>(
     name: &String,
     registers: &HashMap<String, (BasicValueEnum<'ctx>, Option<u64>)>,
 ) -> (BasicValueEnum<'ctx>, Option<u64>) {
-    registers.get(name).unwrap().to_owned()
+    registers.get(name).expect(format!("Register {} not found.", name).as_str()).to_owned()
 }
 
 pub(crate) fn emit<'ctx>(


### PR DESCRIPTION
When running the generator sample it is easy to run it with too few qubits and it will crash. This PR adds two layers of error messages for API consumers to give them a better idea of what failed.