### PR TITLE
Update Instructions for Examples

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -13,7 +13,8 @@ We are working on making them available via other common distribution channels.
 
 To install the pre-built package from GitHub, please install the [GitHub
 CLI](https://cli.github.com/) either directly from the webpage, or alternatively
-use the following [conda](https://docs.conda.io/en/latest/) command from within your conda environment:
+use the following [conda](https://docs.conda.io/en/latest/) command from within
+your conda environment:
 
 ```bash
 conda install -c conda-forge gh

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -13,7 +13,7 @@ We are working on making them available via other common distribution channels.
 
 To install the pre-built package from GitHub, please install the [GitHub
 CLI](https://cli.github.com/) either directly from the webpage, or alternatively
-via the [conda](https://docs.conda.io/en/latest/) command
+use the following [conda](https://docs.conda.io/en/latest/) command from within your conda environment:
 
 ```bash
 conda install -c conda-forge gh

--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -29,8 +29,8 @@ package:
   pip install antlr4-python3-runtime
   ```
 
-  The example can then be run using python, with the generated QIR being outputted
-  to a text file:
+  The example can then be run using python, with the generated QIR being
+  outputted to a text file:
 
   ```bash
   python mock_to_qir.py bernstein_vazirani.txt 8 >> bernstein_vazirani_output.txt
@@ -46,8 +46,8 @@ package:
   e.g., by the fact that there is no `qubit` or `register` type defined within
   the API.
 
-  The example can be run using python, with the generated QIR being outputted to a
-  text file:
+  The example can be run using python, with the generated QIR being
+  outputted to a text file:
 
   ```bash
   python bell_pair.py >> bell_pair_output.txt

--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -29,7 +29,8 @@ package:
   pip install antlr4-python3-runtime
   ```
 
-  The example can then be run using python, with the generated QIR being outputted to a text file:
+  The example can then be run using python, with the generated QIR being outputted
+  to a text file:
 
   ```bash
   python mock_to_qir.py bernstein_vazirani.txt 8 >> bernstein_vazirani_output.txt
@@ -45,7 +46,8 @@ package:
   e.g., by the fact that there is no `qubit` or `register` type defined within
   the API.
 
-  The example can be run using python, with the generated QIR being outputted to a text file:
+  The example can be run using python, with the generated QIR being outputted to a
+  text file:
 
   ```bash
   python bell_pair.py >> bell_pair_output.txt

--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -33,7 +33,7 @@ package:
   written to a text file:
 
   ```bash
-  python mock_to_qir.py bernstein_vazirani.txt 8 >> bernstein_vazirani_output.txt
+  python mock_to_qir.py bernstein_vazirani.txt 7 >> bernstein_vazirani_output.txt
   ```
 
 - **Bell pair example**: <br/>

--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -22,11 +22,17 @@ package:
   QIR. For simplicity, we used [Antlr](https://www.antlr.org/) to generate the
   parser based on the defined
   [grammar](https://github.com/qir-alliance/pyqir/tree/main/examples/generator/mock_language/MockLanguage.g4)
-  and omitted any further compilation or optimization. To run the example,
+  and omitted any further compilation or optimization. Before running the example,
   please install the Antlr runtime:
 
   ```bash
   pip install antlr4-python3-runtime
+  ```
+
+  The example can then be run using python, with the generated QIR being outputted to a text file:
+
+  ```bash
+  python mock_to_qir.py bernstein_vazirani.txt 8 >> bernstein_vazirani_output.txt
   ```
 
 - **Bell pair example**: <br/>
@@ -38,3 +44,9 @@ package:
   and frontend developers* rather than *application developers* - as evidenced,
   e.g., by the fact that there is no `qubit` or `register` type defined within
   the API.
+
+  The example can be run using python, with the generated QIR being outputted to a text file:
+
+  ```bash
+  python bell_pair.py >> bell_pair_output.txt
+  ```

--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -30,7 +30,7 @@ package:
   ```
 
   The example can then be run using python, with the generated QIR being
-  outputted to a text file:
+  written to a text file:
 
   ```bash
   python mock_to_qir.py bernstein_vazirani.txt 8 >> bernstein_vazirani_output.txt
@@ -47,7 +47,7 @@ package:
   the API.
 
   The example can be run using python, with the generated QIR being
-  outputted to a text file:
+  written to a text file:
 
   ```bash
   python bell_pair.py >> bell_pair_output.txt

--- a/examples/jit/README.md
+++ b/examples/jit/README.md
@@ -24,3 +24,9 @@ program](https://github.com/qir-alliance/pyqir/tree/main/examples/jit/bernstein_
   bitcode](https://github.com/qir-alliance/pyqir/tree/main/examples/jit/bernstein_vazirani.bc)
   and then uses the `NonadaptiveJit`, and a custom `GateLogger` to print out a
   simple log of the quantum gates applied during execution.
+
+  The example can be run using python:
+
+  ```bash
+  python bernstein_vazirani.py
+  ```


### PR DESCRIPTION
Updated the installation instructions to make it more clear that the conda command needs to be run from within a conda environment.
Added a bit more instruction on how to run the examples to the example readme files.