### PR TITLE
Bumping version to 0.1.1

### DIFF
--- a/pyqir-generator/Cargo.toml
+++ b/pyqir-generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-generator"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR generator library."

--- a/pyqir-generator/pyproject.toml
+++ b/pyqir-generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir_generator"
-version = "0.1.0a1"
+version = "0.1.1a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir-jit/Cargo.toml
+++ b/pyqir-jit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-jit"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR JIT library."

--- a/pyqir-jit/pyproject.toml
+++ b/pyqir-jit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir_jit"
-version = "0.1.0a1"
+version = "0.1.1a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir-parser/Cargo.toml
+++ b/pyqir-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-parser"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR parser library."

--- a/pyqir-parser/pyproject.toml
+++ b/pyqir-parser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir_parser"
-version = "0.1.0a1"
+version = "0.1.1a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/qirlib/Cargo.toml
+++ b/qirlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qirlib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 description = "Base Profile QIR library"
 


### PR DESCRIPTION
- This change is only for the CI. This does not update the docs which refer to 0.1.0a1. When we cut a release we will have to update the docs.