### PR TITLE
Updating pyo3 and maturin to latest versions.

### DIFF
--- a/pyqir-generator/Cargo.toml
+++ b/pyqir-generator/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.9.0"
 log = "0.4.14"
 
 [dependencies.pyo3]
-version = "0.14.2"
+version = "0.15.1"
 
 [features]
 extension-module = ["pyo3/abi3-py36", "pyo3/extension-module"]

--- a/pyqir-generator/pyproject.toml
+++ b/pyqir-generator/pyproject.toml
@@ -4,5 +4,5 @@ version = "0.1.0a1"
 requires-python = ">=3.6"
 
 [build-system]
-requires = ["maturin>=0.10,<0.12"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"

--- a/pyqir-jit/Cargo.toml
+++ b/pyqir-jit/Cargo.toml
@@ -18,7 +18,7 @@ mut_static = "5.0.0"
 log = "0.4.14"
 
 [dependencies.pyo3]
-version = "0.14.2"
+version = "0.15.1"
 
 [features]
 extension-module = ["pyo3/abi3-py36", "pyo3/extension-module"]

--- a/pyqir-jit/pyproject.toml
+++ b/pyqir-jit/pyproject.toml
@@ -4,5 +4,5 @@ version = "0.1.0a1"
 requires-python = ">=3.6"
 
 [build-system]
-requires = ["maturin>=0.10,<0.12"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"

--- a/pyqir-parser/Cargo.toml
+++ b/pyqir-parser/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 llvm-ir = { version = "0.8.0", features = ["llvm-11"] }
 
 [dependencies.pyo3]
-version = "0.14.2"
+version = "0.15.1"
 
 [features]
 extension-module = ["pyo3/abi3-py36", "pyo3/extension-module"]

--- a/pyqir-parser/pyproject.toml
+++ b/pyqir-parser/pyproject.toml
@@ -4,5 +4,5 @@ version = "0.1.0a1"
 requires-python = ">=3.6"
 
 [build-system]
-requires = ["maturin>=0.10,<0.12"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"


### PR DESCRIPTION
- The 0.15.x pyo3 is the last version to support Python 3.6 which is [EOL Dec 2021](https://www.python.org/dev/peps/pep-0494/#id16)