### PR TITLE
Creating bare context/module/builder for JIT'ing

### DIFF
--- a/pyqir-generator/src/emit.rs
+++ b/pyqir-generator/src/emit.rs
@@ -7,12 +7,12 @@ use inkwell::values::BasicValueEnum;
 use qirlib::context::{Context, ContextType};
 
 use crate::{interop::SemanticModel, qir};
+use qirlib::passes::run_basic_passes_on;
 
 pub fn write_model_to_file(model: &SemanticModel, file_name: &str) -> Result<(), String> {
     let ctx = inkwell::context::Context::create();
     let context = populate_context(&ctx, &model)?;
-    #[cfg(feature = "basic-passes")]
-    qirlib::passes::run_basic_passes_on(&context);
+    run_basic_passes_on(&context.module);
     context.emit_ir(file_name)?;
 
     Ok(())
@@ -21,8 +21,7 @@ pub fn write_model_to_file(model: &SemanticModel, file_name: &str) -> Result<(),
 pub fn get_ir_string(model: &SemanticModel) -> Result<String, String> {
     let ctx = inkwell::context::Context::create();
     let context = populate_context(&ctx, &model)?;
-    #[cfg(feature = "basic-passes")]
-    qirlib::passes::run_basic_passes_on(&context);
+    run_basic_passes_on(&context.module);
     let ir = context.get_ir_string();
 
     Ok(ir)
@@ -31,8 +30,7 @@ pub fn get_ir_string(model: &SemanticModel) -> Result<String, String> {
 pub fn get_bitcode_base64_string(model: &SemanticModel) -> Result<String, String> {
     let ctx = inkwell::context::Context::create();
     let context = populate_context(&ctx, &model)?;
-    #[cfg(feature = "basic-passes")]
-    qirlib::passes::run_basic_passes_on(&context);
+    run_basic_passes_on(&context.module);
     let b64 = context.get_bitcode_base64_string();
 
     Ok(b64)

--- a/pyqir-jit/src/jit.rs
+++ b/pyqir-jit/src/jit.rs
@@ -5,13 +5,17 @@ use std::path::Path;
 
 use crate::interop::SemanticModel;
 use crate::runtime::Simulator;
+use inkwell::module::Module;
 use inkwell::targets::TargetMachine;
-use inkwell::targets::{InitializationConfig, Target};
+use inkwell::{
+    targets::{InitializationConfig, Target},
+    OptimizationLevel,
+};
 use microsoft_quantum_qir_runtime_sys::runtime::BasicRuntimeDriver;
-use qirlib::context::{Context, ContextType};
+use qirlib::context::{BareContext, ContextType};
 use qirlib::passes::run_basic_passes_on;
 
-pub fn run_module<P: AsRef<Path>>(path: P) -> Result<SemanticModel, String> {
+pub fn run_module_file<P: AsRef<Path>>(path: P) -> Result<SemanticModel, String> {
     let ctx = inkwell::context::Context::create();
     let path_str = path
         .as_ref()
@@ -19,12 +23,12 @@ pub fn run_module<P: AsRef<Path>>(path: P) -> Result<SemanticModel, String> {
         .expect("Did not find a valid Unicode path string")
         .to_owned();
     let context_type = ContextType::File(&path_str);
-    let context = Context::new(&ctx, context_type)?;
-    let model = run_ctx(context)?;
+    let context = BareContext::new(&ctx, context_type)?;
+    let model = run_module(&context.module)?;
     Ok(model)
 }
 
-pub fn run_ctx<'ctx>(context: Context<'ctx>) -> Result<SemanticModel, String> {
+pub fn run_module<'ctx>(module: &Module<'ctx>) -> Result<SemanticModel, String> {
     Target::initialize_native(&InitializationConfig::default()).unwrap();
 
     let default_triple = TargetMachine::get_default_triple();
@@ -34,16 +38,18 @@ pub fn run_ctx<'ctx>(context: Context<'ctx>) -> Result<SemanticModel, String> {
     assert!(target.has_asm_backend());
     assert!(target.has_target_machine());
 
-    run_basic_passes_on(&context);
+    run_basic_passes_on(&module);
 
     unsafe {
         BasicRuntimeDriver::initialize_qir_context(true);
         let _ = microsoft_quantum_qir_runtime_sys::foundation::QSharpFoundation::new();
 
         let _ = inkwell::support::load_library_permanently("");
-        let simulator = Simulator::new(&context, &context.execution_engine);
-        let main = context
-            .execution_engine
+        let execution_engine = module
+            .create_jit_execution_engine(OptimizationLevel::None)
+            .expect("Could not create JIT Engine");
+        let simulator = Simulator::new(&module, &execution_engine);
+        let main = execution_engine
             .get_function::<unsafe extern "C" fn() -> ()>("QuantumApplication__Run")
             .unwrap();
         main.call();
@@ -65,7 +71,7 @@ mod tests {
         let mut buffer = File::create(&file_path).unwrap();
         buffer.write_all(bell_qir_measure_contents).unwrap();
 
-        let generated_model = super::run_module(file_path)?;
+        let generated_model = super::run_module_file(file_path)?;
 
         assert_eq!(generated_model.instructions.len(), 2);
         Ok(())

--- a/pyqir-jit/src/python.rs
+++ b/pyqir-jit/src/python.rs
@@ -86,7 +86,7 @@ impl PyNonadaptiveJit {
     }
 
     fn eval(&self, file: String, pyobj: &PyAny) -> PyResult<()> {
-        let result = crate::jit::run_module(file);
+        let result = crate::jit::run_module_file(file);
         if let Err(msg) = result {
             let err: PyErr = PyOSError::new_err::<String>(msg);
             return Err(err);

--- a/pyqir-jit/src/runtime.rs
+++ b/pyqir-jit/src/runtime.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use qirlib::context::Context;
-use qirlib::intrinsics::Intrinsics;
 use crate::gates::CURRENT_GATES;
 use crate::interop::SemanticModel;
 use inkwell::execution_engine::ExecutionEngine;
+use inkwell::module::Module;
+use qirlib::intrinsics::Intrinsics;
 
 use super::gates::GateScope;
 
@@ -14,11 +14,11 @@ pub(crate) struct Simulator {
 }
 
 impl<'ctx> Simulator {
-    pub fn new(context: &Context<'ctx>, ee: &ExecutionEngine<'ctx>) -> Self {
+    pub fn new(module: &Module<'ctx>, ee: &ExecutionEngine<'ctx>) -> Self {
         let simulator = Simulator {
             scope: crate::gates::GateScope::new(),
         };
-        simulator.bind(context, ee);
+        simulator.bind(module, ee);
         simulator
     }
 
@@ -28,8 +28,8 @@ impl<'ctx> Simulator {
         gs.get_model()
     }
 
-    fn bind(&self, context: &Context<'ctx>, ee: &ExecutionEngine<'ctx>) {
-        let intrinsics = Intrinsics::new(&context.module);
+    fn bind(&self, module: &Module<'ctx>, ee: &ExecutionEngine<'ctx>) {
+        let intrinsics = Intrinsics::new(&module);
 
         if let Some(ins) = intrinsics.h_ins {
             ee.add_global_mapping(&ins, super::intrinsics::__quantum__qis__h__body as usize);

--- a/qirlib/src/context.rs
+++ b/qirlib/src/context.rs
@@ -1,12 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
-use inkwell::{OptimizationLevel, memory_buffer::MemoryBuffer, module::Module};
+use inkwell::OptimizationLevel;
 
 use std::path::Path;
 
-use crate::{constants::Constants, intrinsics::Intrinsics, runtime_library::RuntimeLibrary, types::Types};
+use crate::{
+    constants::Constants, intrinsics::Intrinsics, module, runtime_library::RuntimeLibrary,
+    types::Types,
+};
+
+pub struct BareContext<'ctx> {
+    pub context: &'ctx inkwell::context::Context,
+    pub module: inkwell::module::Module<'ctx>,
+    pub builder: inkwell::builder::Builder<'ctx>,
+}
+
+impl<'ctx> BareContext<'ctx> {
+    pub fn new(
+        context: &'ctx inkwell::context::Context,
+        context_type: ContextType<'ctx>,
+    ) -> Result<Self, String> {
+        let builder = context.create_builder();
+        let module = module::load_module(context, context_type)?;
+        Ok(BareContext {
+            builder,
+            module,
+            context,
+        })
+    }
+}
 
 pub struct Context<'ctx> {
     pub context: &'ctx inkwell::context::Context,
@@ -32,7 +55,7 @@ impl<'ctx> Context<'ctx> {
         context_type: ContextType<'ctx>,
     ) -> Result<Self, String> {
         let builder = context.create_builder();
-        let module = Context::load_module(context, context_type)?;
+        let module = module::load_module(context, context_type)?;
         let execution_engine = module
             .create_jit_execution_engine(OptimizationLevel::None)
             .expect("Could not create JIT Engine");
@@ -60,7 +83,7 @@ impl<'ctx> Context<'ctx> {
         context_type: ContextType<'ctx>,
     ) -> Result<Self, String> {
         let builder = context.create_builder();
-        let module = Context::load_module(context, context_type)?;
+        let module = module::load_module(context, context_type)?;
         let types = Types::new(&context, &module);
         let runtime_library = RuntimeLibrary::new(&module);
         let intrinsics = Intrinsics::new(&module);
@@ -78,80 +101,6 @@ impl<'ctx> Context<'ctx> {
 }
 
 impl<'ctx> Context<'ctx> {
-    fn load_module(
-        context: &'ctx inkwell::context::Context,
-        context_type: ContextType<'ctx>,
-    ) -> Result<Module<'ctx>, String> {
-        let module = match context_type {
-            ContextType::Template(name) => {
-                Context::load_module_from_bitcode_template(&context, &name[..])?
-            }
-            ContextType::File(file_name) => {
-                let file_path = Path::new(&file_name[..]);
-                let ext = file_path.extension().and_then(std::ffi::OsStr::to_str);
-                let module = match ext {
-                    Some("ll") => Context::load_module_from_ir_file(file_path, context)?,
-                    Some("bc") => Context::load_module_from_bitcode_file(file_path, context)?,
-                    _ => panic!("Unsupported module exetension {:?}", ext),
-                };
-                module
-            }
-        };
-        Ok(module)
-    }
-    fn load_module_from_bitcode_template(
-        context: &'ctx inkwell::context::Context,
-        name: &'ctx str,
-    ) -> Result<Module<'ctx>, String> {
-        let module_contents = include_bytes!("module.bc");
-        let buffer = MemoryBuffer::create_from_memory_range_copy(module_contents, name);
-        match Module::parse_bitcode_from_buffer(&buffer, context) {
-            Err(err) => {
-                let message = err.to_string();
-                return Err(message);
-            }
-            Ok(module) => Ok(module),
-        }
-    }
-    
-    fn load_module_from_bitcode_file<P: AsRef<Path>>(
-        path: P,
-        context: &'ctx inkwell::context::Context,
-    ) -> Result<Module<'ctx>, String> {
-        match Module::parse_bitcode_from_path(path, context) {
-            Err(err) => {
-                let message = err.to_string();
-                return Err(message);
-            }
-            Ok(module) => Ok(module),
-        }
-    }
-    
-    fn load_module_from_ir_file<P: AsRef<Path>>(
-        path: P,
-        context: &'ctx inkwell::context::Context,
-    ) -> Result<Module<'ctx>, String> {
-        let memory_buffer = Context::load_memory_buffer_from_ir_file(path)?;
-    
-        match context.create_module_from_ir(memory_buffer) {
-            Err(err) => {
-                let message = err.to_string();
-                return Err(message);
-            }
-            Ok(module) => Ok(module),
-        }
-    }
-    
-    fn load_memory_buffer_from_ir_file<P: AsRef<Path>>(path: P) -> Result<MemoryBuffer, String> {
-        match MemoryBuffer::create_from_file(path.as_ref()) {
-            Err(err) => {
-                let message = err.to_string();
-                return Err(message);
-            }
-            Ok(memory_buffer) => Ok(memory_buffer),
-        }
-    }
-    
     pub fn emit_bitcode(&self, file_path: &str) {
         let bitcode_path = Path::new(file_path);
         self.module.write_bitcode_to_path(&bitcode_path);

--- a/qirlib/src/lib.rs
+++ b/qirlib/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod constants;
 pub mod context;
 pub mod intrinsics;
+pub(crate) mod module;
 pub mod runtime_library;
 pub mod passes;
 pub mod types;

--- a/qirlib/src/module.rs
+++ b/qirlib/src/module.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use inkwell::{memory_buffer::MemoryBuffer, module::Module};
+
+use std::path::Path;
+
+use crate::context::ContextType;
+
+pub(crate) fn load_module<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    context_type: ContextType<'ctx>,
+) -> Result<Module<'ctx>, String> {
+    let module = match context_type {
+        ContextType::Template(name) => load_module_from_bitcode_template(&context, &name[..])?,
+        ContextType::File(file_name) => {
+            let file_path = Path::new(&file_name[..]);
+            let ext = file_path.extension().and_then(std::ffi::OsStr::to_str);
+            let module = match ext {
+                Some("ll") => load_module_from_ir_file(file_path, context)?,
+                Some("bc") => load_module_from_bitcode_file(file_path, context)?,
+                _ => panic!("Unsupported module exetension {:?}", ext),
+            };
+            module
+        }
+    };
+    Ok(module)
+}
+
+pub(crate) fn load_module_from_bitcode_template<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    name: &'ctx str,
+) -> Result<Module<'ctx>, String> {
+    let module_contents = include_bytes!("module.bc");
+    let buffer = MemoryBuffer::create_from_memory_range_copy(module_contents, name);
+    match Module::parse_bitcode_from_buffer(&buffer, context) {
+        Err(err) => {
+            let message = err.to_string();
+            return Err(message);
+        }
+        Ok(module) => Ok(module),
+    }
+}
+
+pub(crate) fn load_module_from_bitcode_file<'ctx, P: AsRef<Path>>(
+    path: P,
+    context: &'ctx inkwell::context::Context,
+) -> Result<Module<'ctx>, String> {
+    match Module::parse_bitcode_from_path(path, context) {
+        Err(err) => {
+            let message = err.to_string();
+            return Err(message);
+        }
+        Ok(module) => Ok(module),
+    }
+}
+
+pub(crate) fn load_module_from_ir_file<'ctx, P: AsRef<Path>>(
+    path: P,
+    context: &'ctx inkwell::context::Context,
+) -> Result<Module<'ctx>, String> {
+    let memory_buffer = load_memory_buffer_from_ir_file(path)?;
+
+    match context.create_module_from_ir(memory_buffer) {
+        Err(err) => {
+            let message = err.to_string();
+            return Err(message);
+        }
+        Ok(module) => Ok(module),
+    }
+}
+
+pub(crate) fn load_memory_buffer_from_ir_file<P: AsRef<Path>>(path: P) -> Result<MemoryBuffer, String> {
+    match MemoryBuffer::create_from_file(path.as_ref()) {
+        Err(err) => {
+            let message = err.to_string();
+            return Err(message);
+        }
+        Ok(memory_buffer) => Ok(memory_buffer),
+    }
+}

--- a/qirlib/src/module.rs
+++ b/qirlib/src/module.rs
@@ -19,7 +19,7 @@ pub(crate) fn load_module<'ctx>(
             let module = match ext {
                 Some("ll") => load_module_from_ir_file(file_path, context)?,
                 Some("bc") => load_module_from_bitcode_file(file_path, context)?,
-                _ => panic!("Unsupported module exetension {:?}", ext),
+                _ => panic!("Unsupported module extension {:?}", ext),
             };
             module
         }
@@ -33,26 +33,14 @@ pub(crate) fn load_module_from_bitcode_template<'ctx>(
 ) -> Result<Module<'ctx>, String> {
     let module_contents = include_bytes!("module.bc");
     let buffer = MemoryBuffer::create_from_memory_range_copy(module_contents, name);
-    match Module::parse_bitcode_from_buffer(&buffer, context) {
-        Err(err) => {
-            let message = err.to_string();
-            return Err(message);
-        }
-        Ok(module) => Ok(module),
-    }
+    Module::parse_bitcode_from_buffer(&buffer, context).map_err(|e| e.to_string())
 }
 
 pub(crate) fn load_module_from_bitcode_file<'ctx, P: AsRef<Path>>(
     path: P,
     context: &'ctx inkwell::context::Context,
 ) -> Result<Module<'ctx>, String> {
-    match Module::parse_bitcode_from_path(path, context) {
-        Err(err) => {
-            let message = err.to_string();
-            return Err(message);
-        }
-        Ok(module) => Ok(module),
-    }
+    Module::parse_bitcode_from_path(path, context).map_err(|e| e.to_string())
 }
 
 pub(crate) fn load_module_from_ir_file<'ctx, P: AsRef<Path>>(
@@ -60,22 +48,9 @@ pub(crate) fn load_module_from_ir_file<'ctx, P: AsRef<Path>>(
     context: &'ctx inkwell::context::Context,
 ) -> Result<Module<'ctx>, String> {
     let memory_buffer = load_memory_buffer_from_ir_file(path)?;
-
-    match context.create_module_from_ir(memory_buffer) {
-        Err(err) => {
-            let message = err.to_string();
-            return Err(message);
-        }
-        Ok(module) => Ok(module),
-    }
+    context.create_module_from_ir(memory_buffer).map_err(|e| e.to_string())
 }
 
 pub(crate) fn load_memory_buffer_from_ir_file<P: AsRef<Path>>(path: P) -> Result<MemoryBuffer, String> {
-    match MemoryBuffer::create_from_file(path.as_ref()) {
-        Err(err) => {
-            let message = err.to_string();
-            return Err(message);
-        }
-        Ok(memory_buffer) => Ok(memory_buffer),
-    }
+    MemoryBuffer::create_from_file(path.as_ref()).map_err(|e| e.to_string())
 }

--- a/qirlib/src/passes.rs
+++ b/qirlib/src/passes.rs
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::context::Context;
+use inkwell::module::Module;
 use inkwell::passes::PassManager;
 use inkwell::{
     passes::PassManagerBuilder,
     OptimizationLevel,
 };
 
-pub fn run_basic_passes_on<'ctx>(context: &Context<'ctx>) -> bool {
+// This method returns true if any of the passes modified the function or module and false otherwise.
+pub fn run_basic_passes_on<'ctx>(module: &Module<'ctx>) -> bool {
     let pass_manager_builder = PassManagerBuilder::create();
     pass_manager_builder.set_optimization_level(OptimizationLevel::None);
     let fpm = PassManager::create(());
     fpm.add_global_dce_pass();
     fpm.add_strip_dead_prototypes_pass();
     pass_manager_builder.populate_module_pass_manager(&fpm);
-    fpm.run_on(&context.module)
+    fpm.run_on(module)
 }


### PR DESCRIPTION
JIT no longer needs module template definitions. The compiler passes that had been hidden in the temp feature are now turned on.