### PR TITLE
Format rust workspace source code using cargo fmt

### DIFF
--- a/pyqir-generator/src/lib.rs
+++ b/pyqir-generator/src/lib.rs
@@ -7,4 +7,3 @@ pub mod emit;
 pub mod interop;
 pub mod python;
 pub mod qir;
-

--- a/pyqir-generator/src/python.rs
+++ b/pyqir-generator/src/python.rs
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 
 use log;
-use pyo3::exceptions::{PyOSError};
+use pyo3::exceptions::PyOSError;
 use pyo3::prelude::*;
 use pyo3::PyErr;
 
 use crate::emit::{get_bitcode_base64_string, get_ir_string, write_model_to_file};
-use crate::interop::{ClassicalRegister, Controlled, Instruction, Measured, QuantumRegister, Rotated, SemanticModel, Single};
+use crate::interop::{
+    ClassicalRegister, Controlled, Instruction, Measured, QuantumRegister, Rotated, SemanticModel,
+    Single,
+};
 
 #[pymodule]
 fn pyqir_generator(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -217,4 +220,3 @@ impl PyQIR {
         Ok(())
     }
 }
-

--- a/pyqir-generator/src/qir/basic_values.rs
+++ b/pyqir-generator/src/qir/basic_values.rs
@@ -15,7 +15,10 @@ pub(crate) fn i8_null_ptr<'ctx>(context: &Context<'ctx>) -> BasicMetadataValueEn
         .into()
 }
 
-pub(crate) fn f64_to_f64<'ctx>(context: &Context<'ctx>, value: &f64) -> BasicMetadataValueEnum<'ctx> {
+pub(crate) fn f64_to_f64<'ctx>(
+    context: &Context<'ctx>,
+    value: &f64,
+) -> BasicMetadataValueEnum<'ctx> {
     context
         .types
         .double
@@ -24,7 +27,10 @@ pub(crate) fn f64_to_f64<'ctx>(context: &Context<'ctx>, value: &f64) -> BasicMet
         .into()
 }
 
-pub(crate) fn u64_to_i32<'ctx>(context: &Context<'ctx>, value: u64) -> BasicMetadataValueEnum<'ctx> {
+pub(crate) fn u64_to_i32<'ctx>(
+    context: &Context<'ctx>,
+    value: u64,
+) -> BasicMetadataValueEnum<'ctx> {
     context
         .context
         .i32_type()
@@ -33,7 +39,10 @@ pub(crate) fn u64_to_i32<'ctx>(context: &Context<'ctx>, value: u64) -> BasicMeta
         .into()
 }
 
-pub(crate) fn i64_to_i32<'ctx>(context: &Context<'ctx>, value: i64) -> BasicMetadataValueEnum<'ctx> {
+pub(crate) fn i64_to_i32<'ctx>(
+    context: &Context<'ctx>,
+    value: i64,
+) -> BasicMetadataValueEnum<'ctx> {
     // convert to capture negative values.
     let target: u64 = value as u64;
 
@@ -45,7 +54,10 @@ pub(crate) fn i64_to_i32<'ctx>(context: &Context<'ctx>, value: i64) -> BasicMeta
         .into()
 }
 
-pub(crate) fn u64_to_i64<'ctx>(context: &Context<'ctx>, value: u64) -> BasicMetadataValueEnum<'ctx> {
+pub(crate) fn u64_to_i64<'ctx>(
+    context: &Context<'ctx>,
+    value: u64,
+) -> BasicMetadataValueEnum<'ctx> {
     context
         .types
         .int

--- a/pyqir-generator/src/qir/calls.rs
+++ b/pyqir-generator/src/qir/calls.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use qirlib::context::Context;
 use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, FunctionValue};
+use qirlib::context::Context;
 
 pub(crate) fn emit_void_call<'ctx>(
     context: &Context<'ctx>,

--- a/pyqir-generator/src/qir/instructions.rs
+++ b/pyqir-generator/src/qir/instructions.rs
@@ -7,8 +7,8 @@ use super::{
     array1d::{self, create_ctl_wrapper},
     basic_values, calls,
 };
-use qirlib::context::Context;
 use inkwell::values::{BasicValueEnum, FunctionValue};
+use qirlib::context::Context;
 use std::collections::HashMap;
 
 /// # Panics
@@ -18,7 +18,10 @@ fn get_qubit<'ctx>(
     name: &String,
     qubits: &HashMap<String, BasicValueEnum<'ctx>>,
 ) -> BasicValueEnum<'ctx> {
-    qubits.get(name).expect(format!("Qubit {} not found.", name).as_str()).to_owned()
+    qubits
+        .get(name)
+        .expect(format!("Qubit {} not found.", name).as_str())
+        .to_owned()
 }
 
 /// # Panics
@@ -28,7 +31,10 @@ fn get_register<'ctx>(
     name: &String,
     registers: &HashMap<String, (BasicValueEnum<'ctx>, Option<u64>)>,
 ) -> (BasicValueEnum<'ctx>, Option<u64>) {
-    registers.get(name).expect(format!("Register {} not found.", name).as_str()).to_owned()
+    registers
+        .get(name)
+        .expect(format!("Register {} not found.", name).as_str())
+        .to_owned()
 }
 
 pub(crate) fn emit<'ctx>(

--- a/pyqir-generator/src/qir/mod.rs
+++ b/pyqir-generator/src/qir/mod.rs
@@ -62,5 +62,3 @@ pub(crate) fn remove_quantumapplication_run_interop<'ctx>(
     context.builder.build_return(Some(&v));
     entrypoint
 }
-
-

--- a/pyqir-jit/src/intrinsics.rs
+++ b/pyqir-jit/src/intrinsics.rs
@@ -11,7 +11,7 @@ pub struct QirRTuple {
 
 pub type PauliId = i8;
 
-use microsoft_quantum_qir_runtime_sys::runtime::{QirArray,QirRuntime, QUBIT};
+use microsoft_quantum_qir_runtime_sys::runtime::{QirArray, QirRuntime, QUBIT};
 use mut_static::ForceSomeRwLockWriteGuard;
 
 use super::gates::BaseProfile;

--- a/pyqir-jit/src/python.rs
+++ b/pyqir-jit/src/python.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::interop::Instruction;
 use log;
-use pyo3::exceptions::{PyOSError};
+use pyo3::exceptions::PyOSError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::PyErr;
-use crate::interop::{
-    Instruction
-};
-
 
 #[pymodule]
 fn pyqir_jit(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -19,14 +16,13 @@ fn pyqir_jit(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 }
 
 #[pyclass]
-pub struct PyNonadaptiveJit {
-}
+pub struct PyNonadaptiveJit {}
 
 #[pymethods]
 impl PyNonadaptiveJit {
     #[new]
     fn new() -> Self {
-        PyNonadaptiveJit { }
+        PyNonadaptiveJit {}
     }
 
     fn controlled(

--- a/pyqir-parser/src/python.rs
+++ b/pyqir-parser/src/python.rs
@@ -9,11 +9,11 @@
 // from within rust, and wrappers for each class and function will be added to __init__.py so that the
 // parser API can have full python doc comments for usability.
 
-use pyo3::exceptions::{PyRuntimeError};
+use super::parse::*;
 use llvm_ir;
 use llvm_ir::types::Typed;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use super::parse::*;
 use std::convert::TryFrom;
 
 #[pymodule]

--- a/qirlib/src/lib.rs
+++ b/qirlib/src/lib.rs
@@ -7,6 +7,6 @@ pub mod constants;
 pub mod context;
 pub mod intrinsics;
 pub(crate) mod module;
-pub mod runtime_library;
 pub mod passes;
+pub mod runtime_library;
 pub mod types;

--- a/qirlib/src/module.rs
+++ b/qirlib/src/module.rs
@@ -48,9 +48,13 @@ pub(crate) fn load_module_from_ir_file<'ctx, P: AsRef<Path>>(
     context: &'ctx inkwell::context::Context,
 ) -> Result<Module<'ctx>, String> {
     let memory_buffer = load_memory_buffer_from_ir_file(path)?;
-    context.create_module_from_ir(memory_buffer).map_err(|e| e.to_string())
+    context
+        .create_module_from_ir(memory_buffer)
+        .map_err(|e| e.to_string())
 }
 
-pub(crate) fn load_memory_buffer_from_ir_file<P: AsRef<Path>>(path: P) -> Result<MemoryBuffer, String> {
+pub(crate) fn load_memory_buffer_from_ir_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<MemoryBuffer, String> {
     MemoryBuffer::create_from_file(path.as_ref()).map_err(|e| e.to_string())
 }

--- a/qirlib/src/passes.rs
+++ b/qirlib/src/passes.rs
@@ -3,10 +3,7 @@
 
 use inkwell::module::Module;
 use inkwell::passes::PassManager;
-use inkwell::{
-    passes::PassManagerBuilder,
-    OptimizationLevel,
-};
+use inkwell::{passes::PassManagerBuilder, OptimizationLevel};
 
 // This method returns true if any of the passes modified the function or module and false otherwise.
 pub fn run_basic_passes_on<'ctx>(module: &Module<'ctx>) -> bool {


### PR DESCRIPTION
This commit was created from the running of `cargo fmt --all` from the root of the workspace. Some text editors / IDEs have a "Format on Save" option, which when enabled will execute `cargo fmt` on a per-file basis.

It might be nice to have formatting checks added to an Action at some point. I'd be happy to follow up with another PR to add such a check. 