### PR TITLE
Fix documentation links that couldn't be checked as part of the first docs PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ by the above Python packages.
 ## Documentation
 
 - [Installing
-  PyQIR](https://github.com/qir-alliance/pyqir/blob/main/docs/installing.md)
+  PyQIR](https://qir-alliance.github.io/pyqir/getting-started/installing.html)
 - [Building PyQIR from
-  source](https://github.com/qir-alliance/pyqir/blob/main/docs/building.md)
-- [Compatibility](https://github.com/qir-alliance/pyqir/blob/main/docs/compatibility.md)
+  source](https://qir-alliance.github.io/pyqir/development-guide/building.html)
+- [Compatibility](https://qir-alliance.github.io/pyqir/development-guide/compatibility.html)
 
 ## Feedback
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,4 +32,4 @@ Intermediate Representation (QIR)](https://github.com/qir-alliance/qir-spec).
 
 For more information about how to install the PyQIR packages to run the
 examples, see the
-[docs](https://github.com/qir-alliance/pyqir/blob/main/getting-started/installing.md).
+[docs](https://qir-alliance.github.io/pyqir/getting-started/installing.html).

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,4 +32,4 @@ Intermediate Representation (QIR)](https://github.com/qir-alliance/qir-spec).
 
 For more information about how to install the PyQIR packages to run the
 examples, see the
-[docs](https://github.com/qir-alliance/pyqir/blob/main/docs/installing.md).
+[docs](https://github.com/qir-alliance/pyqir/blob/main/getting-started/installing.md).

--- a/examples/jit/README.md
+++ b/examples/jit/README.md
@@ -5,7 +5,7 @@ purpose of
 
 1. easily testing and experimenting with QIR code
 2. connecting it to low-level Python-based lab software such as e.g.
-   [QCoDes.](https://qcodes.github.io/Qcodes/user/intro.html)
+   [QCoDeS](https://qcodes.github.io/Qcodes/examples/15_minutes_to_QCoDeS.html#Introduction).
 
 It contains the necessary [just-in-time
 compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation)

--- a/pyqir-generator/README.md
+++ b/pyqir-generator/README.md
@@ -86,7 +86,7 @@ entry:
 
 ## Building and Testing
 
-See [Building](https://github.com/qir-alliance/pyqir/blob/main/docs/building.md)
+See [Building](https://qir-alliance.github.io/pyqir/development-guide/building.html)
 
 ## Current Limitations
 

--- a/pyqir-jit/README.md
+++ b/pyqir-jit/README.md
@@ -5,7 +5,7 @@ purpose of
 
 1. easily testing and experimenting with QIR code
 2. connecting it to low-level Python-based lab software such as e.g.
-   [QCoDes.](https://qcodes.github.io/Qcodes/user/intro.html)
+   [QCoDeS](https://qcodes.github.io/Qcodes/examples/15_minutes_to_QCoDeS.html#Introduction)
 
 It contains the necessary [just-in-time
 compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation)

--- a/pyqir-jit/README.md
+++ b/pyqir-jit/README.md
@@ -86,7 +86,7 @@ measure qubits[8] -> out[8]
 
 ## Building and Testing
 
-See [Building](https://github.com/qir-alliance/pyqir/blob/main/docs/building.md)
+See [Building](https://qir-alliance.github.io/pyqir/development-guide/building.html)
 
 ## Current Limitations
 

--- a/pyqir-parser/README.md
+++ b/pyqir-parser/README.md
@@ -4,7 +4,7 @@ Under active development and will be updated.
 
 ## Building and Testing
 
-See [Building](https://github.com/qir-alliance/pyqir/blob/main/docs/building.md)
+See [Building](https://qir-alliance.github.io/pyqir/development-guide/building.html)
 
 ## Limitations
 


### PR DESCRIPTION
The link checks for the original docs PR somehow passed with broken links. We still have the issue that we can't point to docs until after publishing, but we'll need to address that in a separate PR.