### PR TITLE
Use new CodeGenModel trait for generation to allow extensibility

### DIFF
--- a/qirlib/src/generation/qir/instructions.rs
+++ b/qirlib/src/generation/qir/instructions.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 /// # Panics
 ///
 /// Panics if the qubit name doesn't exist
-fn get_qubit<'ctx>(
+pub fn get_qubit<'ctx>(
     name: &str,
     qubits: &HashMap<String, BasicValueEnum<'ctx>>,
 ) -> BasicValueEnum<'ctx> {
@@ -19,7 +19,7 @@ fn get_qubit<'ctx>(
         .unwrap_or_else(|| panic!("Qubit {} not found.", name))
 }
 
-fn measure<'ctx>(
+pub fn measure<'ctx>(
     generator: &CodeGenerator<'ctx>,
     qubit: &str,
     target: &str,
@@ -38,7 +38,7 @@ fn measure<'ctx>(
     registers.insert(target.to_owned(), Some(new_value.into_pointer_value()));
 }
 
-fn controlled<'ctx>(
+pub fn controlled<'ctx>(
     generator: &CodeGenerator<'ctx>,
     intrinsic: FunctionValue<'ctx>,
     control: BasicValueEnum<'ctx>,


### PR DESCRIPTION
Baased on https://github.com/qir-alliance/pyqir/pull/46, only the final few commits are new.

Other tools may wish to use the same code generation utilities but with a different "SemanticModel", this trait allows for that.

As there are accessors for all members `SemanticModel` members are made private.

Instruction code gen utilities are made public for reuse.

These changes are used [here](https://github.com/CQCL/tket-qir/tree/generate):  to protoype QIR code generation from the [tket](https://github.com/CQCL/tket) JSON IR.

