### PR TITLE
Improve error handling for invalid external function calls

### DIFF
--- a/pyqir-generator/tests/test_external_functions.py
+++ b/pyqir-generator/tests/test_external_functions.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from pyqir.generator import BasicQisBuilder, SimpleModule, Value, types
-from typing import Callable, List, Tuple
+from typing import Any, Callable, List, Tuple
 import unittest
 
 
@@ -117,9 +117,12 @@ class ExternalFunctionsTest(unittest.TestCase):
         )
 
     def test_wrong_type(self) -> None:
-        cases: List[Tuple[List[types.Value], Callable[[SimpleModule], List[Value]]]] = [
-            ([types.INT], lambda _: [1.23]),
+        cases: List[Tuple[List[types.Value], Callable[[SimpleModule], List[Any]]]] = [
+            ([types.BOOL], lambda _: ["true"]),
             ([types.BOOL], lambda mod: [mod.results[0]]),
+            ([types.INT], lambda _: [1.23]),
+            ([types.INT], lambda _: ["123"]),
+            ([types.DOUBLE], lambda _: ["1.23"]),
             ([types.QUBIT], lambda mod: [mod.results[0]]),
             ([types.RESULT], lambda mod: [mod.qubits[0]]),
         ]

--- a/qirlib/src/generation/interop.rs
+++ b/qirlib/src/generation/interop.rs
@@ -153,10 +153,38 @@ pub struct FunctionType {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
-    Integer { width: u32, value: u64 },
+    Integer(IntegerValue),
     Double(f64),
     Qubit(String),
     Result(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IntegerValue {
+    width: u32,
+    value: u64,
+}
+
+impl IntegerValue {
+    /// Creates a new `IntegerValue`, returning `None` if the number of bits required to represent
+    /// `value` is greater than `width`.
+    #[must_use]
+    pub fn new(width: u32, value: u64) -> Option<IntegerValue> {
+        let value_width = u64::BITS - u64::leading_zeros(value);
+        if value_width > width {
+            None
+        } else {
+            Some(IntegerValue { width, value })
+        }
+    }
+
+    pub(crate) fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub(crate) fn value(&self) -> u64 {
+        self.value
+    }
 }
 
 #[derive(Clone)]

--- a/qirlib/src/generation/qir/instructions.rs
+++ b/qirlib/src/generation/qir/instructions.rs
@@ -162,10 +162,10 @@ fn emit_call<'ctx>(
         .args
         .iter()
         .map(|value| match value {
-            Value::Integer { width, value } => generator
+            Value::Integer(value) => generator
                 .context
-                .custom_width_int_type(*width)
-                .const_int(*value, false)
+                .custom_width_int_type(value.width())
+                .const_int(value.value(), false)
                 .into(),
             Value::Double(value) => generator.f64_to_f64(*value),
             Value::Qubit(name) => get_qubit(qubits, name).into(),


### PR DESCRIPTION
- Add test cases for wrong argument types, overflowing integers, and wrong number of arguments.
- Explicitly check that the number of arguments given matches the type of the function (instead of dropping additional arguments).
- Explicitly check for integer values that would overflow the width of the integer type.