### PR TITLE
Python subset to QIR

### DIFF
--- a/examples/generator/README.md
+++ b/examples/generator/README.md
@@ -69,3 +69,13 @@ linked with a separate library at compile time.
 
 Note that it's not currently possible to use the return value of an external
 function in subsequent instructions.
+
+## Python subset to QIR
+
+[python2qir.py](python2qir.py) transforms a subset of the Python language into QIR, by using:
+- the built-in `ast` (Asbtract Syntax Tree) library to parse the source code
+- the `pyqir-generator` package to generate and display QIR
+
+Here, we transform a Qiskit circuit without using the Qiskit package.
+
+

--- a/examples/generator/python2qir.py
+++ b/examples/generator/python2qir.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Transforms a subset of the Python language into QIR, by using:
+# - the built-in ast (Asbtract Syntax Tree) library to parse the source code
+# - the pyqir-generator package to generate and display QIR
+# Here, we transform a Qiskit circuit without using the Qiskit package
+
+import ast
+
+from pyqir.generator import BasicQisBuilder, SimpleModule
+
+
+def main():
+    # Open and parse the input file
+    with open("python2qir_qiskit_input.py", "r") as source:
+        tree = ast.parse(source.read())
+
+    # Walk the Abstract Syntax Tree (AST) and translate into QIR with pyqir-generator
+    analyzer = Analyzer()
+    analyzer.visit(tree)
+
+    print("\n\n== Output QIR ==")
+    print(analyzer.module.ir())
+
+
+class Analyzer(ast.NodeVisitor):
+    module: SimpleModule
+    builder: BasicQisBuilder
+
+    def __init__(self):
+        pass
+
+    def visit_Call(self, node: ast.Call):
+
+        if isinstance(node.func, ast.Name):
+            name: ast.Name = node.func
+            if name.id == "QuantumCircuit":
+                num_qubits = node.args[0].value
+                num_results = node.args[1].value
+                self.module = SimpleModule("python2qir", num_qubits, num_results)
+                self.builder = BasicQisBuilder(self.module.builder)
+
+        if isinstance(node.func, ast.Attribute):
+            attribute: ast.Attribute = node.func
+            if attribute.attr == "cx":
+                control = node.args[0].value
+                target = node.args[1].value
+                self.builder.cx(self.module.qubits[control], self.module.qubits[target])
+            if attribute.attr == "h":
+                qubit = node.args[0].value
+                self.builder.h(self.module.qubits[qubit])
+            if attribute.attr == "measure":
+                qubit = node.args[0].value
+                bit = node.args[1].value
+                self.builder.m(self.module.qubits[qubit], self.module.results[bit])
+            if attribute.attr == "z":
+                qubit = node.args[0].value
+                self.builder.z(self.module.qubits[qubit])
+        self.generic_visit(node)
+
+
+main()

--- a/examples/generator/python2qir_qiskit_input.py
+++ b/examples/generator/python2qir_qiskit_input.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Bernstein-Vazirani algorithm on 6 qubits with Qiskit
+
+from qiskit import Aer, execute, QuantumCircuit
+
+qc = QuantumCircuit(7, 6)
+
+# Set first 6 qubits to |+>
+qc.h(0)
+qc.h(1)
+qc.h(2)
+qc.h(3)
+qc.h(4)
+qc.h(5)
+
+# Set ancilla qubit to |->
+qc.h(6)
+qc.z(6)
+
+# Apply oracle
+qc.cx(1, 6)
+qc.cx(3, 6)
+qc.cx(5, 6)
+
+# Apply Hadamard to the first 6 qubits
+qc.h(5)
+qc.h(4)
+qc.h(3)
+qc.h(2)
+qc.h(1)
+qc.h(0)
+
+# Measure the first 6 qubits
+qc.measure(0, 0)
+qc.measure(1, 1)
+qc.measure(2, 2)
+qc.measure(3, 3)
+qc.measure(4, 4)
+qc.measure(5, 5)
+
+# Simulate the circuit
+job = execute(qc, Aer.get_backend("qasm_simulator"), shots=1024)
+
+# Display the result
+counts = job.result().get_counts(qc)
+print(counts)


### PR DESCRIPTION
As requested in #100.

Transforms a subset of the Python language into QIR, by using:
- the built-in ast (Asbtract Syntax Tree) library to parse the source code
- the pyqir-generator package to generate and display QIR

Here, we transform a Qiskit circuit without using the Qiskit package.
