### PR TITLE
Add conditional feature support for python bindings and more LLVM versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,12 +171,14 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#36c3b106e61b1b45295a35f94023d93d9328c76f"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#bff378bee02bcbb5bed35f47e9ed69e6642e9188"
 dependencies = [
  "either",
  "inkwell_internals",
  "libc",
- "llvm-sys",
+ "llvm-sys 110.0.3",
+ "llvm-sys 120.2.4",
+ "llvm-sys 130.0.4",
  "once_cell",
  "parking_lot 0.12.0",
 ]
@@ -175,7 +186,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.5.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#36c3b106e61b1b45295a35f94023d93d9328c76f"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#bff378bee02bcbb5bed35f47e9ed69e6642e9188"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -199,9 +210,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "llvm-ir"
@@ -210,7 +221,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f292d36cc01be049372faa8e5fb4aaa261d4875f7d5cdc59a86353434b7ed02"
 dependencies = [
  "either",
- "llvm-sys",
+ "llvm-sys 110.0.3",
+ "llvm-sys 120.2.4",
+ "llvm-sys 130.0.4",
  "log",
 ]
 
@@ -224,7 +237,33 @@ dependencies = [
  "lazy_static",
  "libc",
  "regex",
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "llvm-sys"
+version = "120.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b716322964966a62377cf86e64f00ca7043505fdf27bd2ec7d41ae6682d1e7"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "llvm-sys"
+version = "130.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb6ea20e8a348f6db0b43a7f009fa7d981d22edf4cbe2e0c7b2247dbb25be61"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -239,18 +278,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mut_static"
@@ -291,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.2",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -310,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
@@ -363,18 +402,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
+checksum = "d41d50a7271e08c7c8a54cd24af5d62f73ee3a6f6a314215281ebdec421d5752"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -388,18 +427,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
+checksum = "779239fc40b8e18bc8416d3a37d280ca9b9fb04bda54b98037bb6748595c2410"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+checksum = "00b247e8c664be87998d8628e86f282c25066165f1f8dda66100c48202fdb93a"
 dependencies = [
  "pyo3-macros-backend",
  "quote",
@@ -408,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
+checksum = "5a8c2812c412e00e641d99eeb79dd478317d981d938aa60325dfa7157b607095"
 dependencies = [
  "proc-macro2",
  "pyo3-build-config",
@@ -422,7 +461,6 @@ dependencies = [
 name = "pyqir-evaluator"
 version = "0.4.0-alpha"
 dependencies = [
- "inkwell",
  "pyo3",
  "qirlib",
  "serial_test",
@@ -433,7 +471,6 @@ name = "pyqir-generator"
 version = "0.4.0-alpha"
 dependencies = [
  "env_logger",
- "inkwell",
  "log",
  "pyo3",
  "qirlib",
@@ -453,23 +490,27 @@ version = "0.3.0"
 dependencies = [
  "base64",
  "bitvec",
+ "cc",
+ "cmake",
  "cty",
  "inkwell",
  "lazy_static",
- "llvm-sys",
+ "llvm-sys 110.0.3",
  "log",
  "mut_static",
  "normalize-line-endings",
  "rand",
+ "regex",
+ "semver 1.0.9",
  "serial_test",
  "tempfile",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -561,6 +602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,9 +646,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -645,9 +692,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "unindent"
@@ -694,9 +741,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -707,33 +754,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"

--- a/cspell.json
+++ b/cspell.json
@@ -7,15 +7,13 @@
         // The name of the package itself.
         "pyqir",
         "qirlib",
-        
         // General quantum terminology.
         "qubit",
         "qubits",
-        
         // General classical terminology.
         "codegen",
         "toolchain",
-        
+        "POSIX",
         // Python and Rust specific terminology.
         "maturin",
         "venv",
@@ -26,20 +24,21 @@
         "pypa",
         "manylinux",
         "rustfmt",
-        "clippy",       
-        
+        "clippy",
+        "bitvec",
+        "tempfile",
         // LLVM terminology and keywords.
         "entrypoint",
-        
         // CI and build pipeline terminology.
         "ccache",
         "sccache",
-        "pwsh"
+        "pwsh",
+        "cmake",
+        "alltargets"
     ],
     // By definition, everything in flagWords is considered to be spelled
     // wrong. Thus we disable spell checking for the list of misspelled words...
     // cspell:disable
-    "flagWords": [
-    ]
+    "flagWords": []
     // cspell:enable
 }

--- a/pyqir-generator/Cargo.toml
+++ b/pyqir-generator/Cargo.toml
@@ -19,7 +19,8 @@ qirlib = { path = "../qirlib" }
 
 [features]
 extension-module = ["pyo3/abi3-py36", "pyo3/extension-module"]
-default = ["extension-module"]
+python-bindings = []
+default = ["extension-module", "python-bindings"]
 
 [lib]
 name = "pyqir_generator"

--- a/pyqir-generator/src/lib.rs
+++ b/pyqir-generator/src/lib.rs
@@ -10,4 +10,5 @@
 //     we can directly control in our code.
 #![allow(clippy::needless_option_as_deref)]
 
+#[cfg(feature = "python-bindings")]
 pub mod python;

--- a/pyqir-parser/Cargo.toml
+++ b/pyqir-parser/Cargo.toml
@@ -12,14 +12,18 @@ repository = "https://github.com/qir-alliance/pyqir"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-llvm-ir = { version = "0.8.0", features = ["llvm-11"] }
+llvm-ir = "0.8.1"
 
 [dependencies.pyo3]
 version = "0.15.1"
 
 [features]
 extension-module = ["pyo3/abi3-py36", "pyo3/extension-module"]
-default = ["extension-module"]
+python-bindings = []
+llvm-11 = ["llvm-ir/llvm-11"]
+llvm-12 = ["llvm-ir/llvm-12"]
+llvm-13 = ["llvm-ir/llvm-13"]
+default = ["extension-module", "python-bindings", "llvm-11"]
 
 [lib]
 name = "pyqir_parser"
@@ -27,7 +31,7 @@ crate-type = ["cdylib"]
 
 [package.metadata.maturin]
 name = "pyqir.parser._native"
-classifier=[
+classifier = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/pyqir-parser/src/lib.rs
+++ b/pyqir-parser/src/lib.rs
@@ -6,4 +6,5 @@
 #![allow(clippy::used_underscore_binding)]
 
 pub mod parse;
+#[cfg(feature = "python-bindings")]
 pub mod python;

--- a/qirlib/Cargo.toml
+++ b/qirlib/Cargo.toml
@@ -12,7 +12,9 @@ rust-version = "1.56"
 
 [dependencies]
 llvm-sys = "110"
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", default-features = false, features = ["llvm11-0", "target-x86"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", default-features = false, features = [
+    "target-x86",
+] }
 log = "0.4.14"
 cty = "0.2.1"
 rand = "0.8.4"
@@ -37,19 +39,26 @@ semver = "1.0.6"
 name = "qirlib"
 
 [features]
+llvm-11 = ["inkwell/llvm11-0"]
+llvm-12 = ["inkwell/llvm12-0"]
+llvm-13 = ["inkwell/llvm13-0"]
 
 # default to use llvm-sys/inkwell for llvm linking
-default = ["external-llvm-linking"]
+default = ["external-llvm-linking", "llvm-11"]
 external-llvm-linking = []
 # disable linking for local installation or packaging
-no-llvm-linking = ["llvm-sys/disable-alltargets-init", "inkwell/llvm11-0-no-llvm-linking"]
+no-llvm-linking = [
+    "llvm-sys/disable-alltargets-init",
+    "inkwell/llvm11-0-no-llvm-linking",
+]
 # let qirlib do the llvm linking
-qirlib-llvm-linking = ["llvm-sys/disable-alltargets-init", "inkwell/llvm11-0-no-llvm-linking"]
+qirlib-llvm-linking = [
+    "llvm-sys/disable-alltargets-init",
+    "inkwell/llvm11-0-no-llvm-linking",
+]
 
 download-llvm = []
 build-llvm = []
 
 # Dev use only for packaging LLVM builds
 package-llvm = ["build-llvm", "no-llvm-linking"]
-
-


### PR DESCRIPTION
I'm working on integrating these crates into some of our QIR work, and it would be nice to not include the Python bindings in places where they are not needed. 

Additionally, at least one of our projects allows the use of LLVM version up to 12 or 13, so this PR also includes more features in each crate that uses `llvm-ir` or `inkwell` to support those versions too. 

All `default-features` have been kept unchanged, so the crates should function precisely the same as if none of the new features were added. 

I've confirmed, at least locally, that our downstream projects work as expected when using/disabling these features.