### PR TITLE
Set LLVM 13 as the default

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "amd64",
               env: {},
             }
@@ -46,8 +46,8 @@ jobs:
       - name: MacOS - Install build dependencies, ccache, ninja
         run: brew install ccache ninja
         if: ${{ matrix.config.os == 'macOS-10.15' }}
-      - name: Windows - Install LLVM 11.1.0
-        run: choco install llvm --version=11.1.0 --allow-downgrade
+      - name: Windows - Install LLVM 13.0.1
+        run: choco install llvm --version=13.0.1 --allow-downgrade
         if: ${{ matrix.config.os == 'windows-2019' }}
       - name: "Build and Package LLVM"
         run: ./build.ps1 -t package-llvm

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -52,6 +52,11 @@ jobs:
       - name: "Build and Package LLVM"
         run: ./build.ps1 -t package-llvm
         shell: pwsh
+        if: ${{ matrix.config.os != 'ubuntu-20.04' }}
+      - name: "Build and Package LLVM for manylinux"
+        run: ./build.ps1 -t package-manylinux-llvm
+        shell: pwsh
+        if: ${{ matrix.config.os == 'ubuntu-20.04' }}
       - name: Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -63,7 +63,7 @@ jobs:
           name: artifacts
           if-no-files-found: error
           path: |
-            target/*.zip
-            target/*.tar.gz
-            target/*.rpm
-            target/*.deb
+            target/**/*.zip
+            target/**/*.tar.gz
+            target/**/*.rpm
+            target/**/*.deb

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: 'recursive'
       - name: Linux - Install build dependencies, ccache, ninja
         run: sudo apt-get install -y ccache ninja-build
-        if: ${{ matrix.config.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.config.os == 'ubuntu-22.04' }}
       - name: Windows - Install build dependencies, sccache, ninja
         run: choco install --accept-license -y sccache ninja
         if: ${{ matrix.config.os == 'windows-2019' }}
@@ -52,11 +52,11 @@ jobs:
       - name: "Build and Package LLVM"
         run: ./build.ps1 -t package-llvm
         shell: pwsh
-        if: ${{ matrix.config.os != 'ubuntu-20.04' }}
+        if: ${{ matrix.config.os != 'ubuntu-22.04' }}
       - name: "Build and Package LLVM for manylinux"
         run: ./build.ps1 -t package-manylinux-llvm
         shell: pwsh
-        if: ${{ matrix.config.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.config.os == 'ubuntu-22.04' }}
       - name: Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,6 @@ cython_debug/
 /.cargo/config.toml
 wheelhouse/
 
+/.vscode/settings.json
+
 .local/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir-evaluator"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 dependencies = [
  "pyo3",
  "qirlib",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir-generator"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 dependencies = [
  "pyo3",
  "qirlib",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir-parser"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 dependencies = [
  "llvm-ir",
  "pyo3",

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.5.0a1] - 2022-07-13
+
+- Added mypy github action to check type annotations and mypy stub files by @WingCode in https://github.com/qir-alliance/pyqir/pull/127
+- Evaluator: Raise if bitcode contains unknown external functions. by @georgios-ts in https://github.com/qir-alliance/pyqir/pull/128
+- Regenerate mock parser using ANTLR-4.10 by @georgios-ts in https://github.com/qir-alliance/pyqir/pull/129
+- Set LLVM 13 as the default by @idavis in https://github.com/qir-alliance/pyqir/pull/131
+- Fix type hinting errors by @LaurentAjdnik in https://github.com/qir-alliance/pyqir/pull/133
+- Create CODEOWNERS by @samarsha in https://github.com/qir-alliance/pyqir/pull/134
+
+
 ## [0.4.2a1] - 2022-06-03
 
 - Adding ability to do musl/alpine builds by @idavis in https://github.com/qir-alliance/pyqir/pull/111
@@ -109,7 +119,8 @@ class:
 
 - Initial Release
 
-[Unreleased]: https://github.com/qir-alliance/pyqir/compare/v0.4.2a1...HEAD
+[Unreleased]: https://github.com/qir-alliance/pyqir/compare/v0.5.0a1...HEAD
+[0.5.0a1]: https://github.com/qir-alliance/pyqir/compare/v0.4.2a1...v0.5.0a1
 [0.4.2a1]: https://github.com/qir-alliance/pyqir/compare/v0.4.1a1...v0.4.2a1
 [0.4.1a1]: https://github.com/qir-alliance/pyqir/compare/v0.4.0a1...v0.4.1a1
 [0.4.0a1]: https://github.com/qir-alliance/pyqir/compare/v0.3.2a1...v0.4.0a1

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,6 @@
 - Fix type hinting errors by @LaurentAjdnik in https://github.com/qir-alliance/pyqir/pull/133
 - Create CODEOWNERS by @samarsha in https://github.com/qir-alliance/pyqir/pull/134
 
-
 ## [0.4.2a1] - 2022-06-03
 
 - Adding ability to do musl/alpine builds by @idavis in https://github.com/qir-alliance/pyqir/pull/111

--- a/docs/development-guide/building.md
+++ b/docs/development-guide/building.md
@@ -4,11 +4,11 @@
 
 ### Requirements
 
-- [Rust 1.56+](https://rustup.rs/)
+- [Rust 1.57+](https://rustup.rs/)
 - [Python 3.6+](https://www.python.org)
 - [PowerShell 7+
   (Core)](https://github.com/powershell/powershell#get-powershell)
-- [LLVM/Clang 11.1.0](https://llvm.org/) - See [Installing
+- [LLVM/Clang 13.0.1](https://llvm.org/) - See [Installing
   LLVM](#installing-llvm)
 - If compiling LLVM from source:
   - [CMake 3.10+](https://github.com/Kitware/CMake/releases/tag/v3.10.3)
@@ -63,25 +63,23 @@ Install Rust from [rustup](https://rustup.rs/).
 
 ### Installing Clang and Ninja
 
-If you have a working installation of LLVM and [Clang](https://clang.llvm.org/),
-each project can be built by running `cargo build` in the project directory. If
-not, you can install Clang manually:
+You can install Clang manually:
 
-- Linux (Ubuntu)
+- Linux (Ubuntu 22.04)
 
   ```bash
   apt-get update
-  apt-get install -y clang-11 lldb-11 lld-11 clangd-11
-  apt-get install -y --no-install-recommends ninja-build clang-tidy-11 build-essential
+  apt-get install -y clang-13 lldb-13 lld-11 clangd-13
+  apt-get install -y --no-install-recommends ninja-build clang-tidy-13 build-essential
   ```
 
 - Windows
-  - Download and install the `LLVM-11.1.0-win64.exe` from the [11.1.0
-    Release](https://github.com/llvm/llvm-project/releases/tag/llvmorg-11.1.0)
+  - Download and install the `LLVM-13.0.1-win64.exe` from the [13.0.1
+    Release](https://github.com/llvm/llvm-project/releases/tag/llvmorg-13.0.1)
     page.
   - This package only contains the Clang components. There is no package that
     contains Clang and LLVM.
-  - MacOS
+- MacOS
   - Should be preinstalled.
 
 ### Installing LLVM

--- a/eng/psakefile.ps1
+++ b/eng/psakefile.ps1
@@ -5,6 +5,10 @@ properties {
     $repo = @{}
     $repo.root = Resolve-Path (Split-Path -parent $PSScriptRoot)
     $repo.target = Join-Path $repo.root "target"
+    $repo.dot_cargo = Join-Path $repo.root ".cargo"
+    $repo.workspace_config_file = Join-Path $repo.dot_cargo "config.toml"
+    $repo.dot_vscode = Join-Path $repo.root ".vscode"
+    $repo.vscode_config_file = Join-Path $repo.dot_vscode "settings.json"
 
     $pyqir = @{}
 

--- a/eng/psakefile.ps1
+++ b/eng/psakefile.ps1
@@ -74,7 +74,7 @@ task run-manylinux-container-image -preaction { Write-CacheStats } -postaction {
 
     $cacheMount, $cacheEnv = Get-CCacheParams
 
-    Write-BuildLog "Running container image:"
+    Write-BuildLog "Running container image: $($linux.manylinux_tag)"
     $ioVolume = "$($srcPath):$($linux.manylinux_root)"
     $userName = Get-LinuxContainerUserName
 
@@ -93,7 +93,7 @@ task run-musllinux-container-image -preaction { Write-CacheStats } -postaction {
 
     $cacheMount, $cacheEnv = Get-CCacheParams
 
-    Write-BuildLog "Running container image:"
+    Write-BuildLog "Running container image: $($linux.musllinux_tag)"
     $ioVolume = "$($srcPath):$($linux.musllinux_root)"
     $userName = Get-LinuxContainerUserName
     if (Test-CI) {
@@ -243,17 +243,19 @@ task check-environment {
         "Neither the VIRTUAL_ENV nor CONDA_PREFIX environment variables are set).",
         "See https://virtualenv.pypa.io/en/latest/index.html on how to use virtualenv"
     )
-    if((Test-InVirtualEnvironment) -eq $false) {
+    if ((Test-InVirtualEnvironment) -eq $false) {
         Write-BuildLog "No virtual environment found."
         $pyenv = Join-Path $repo.target ".env"
         Write-BuildLog "Setting up virtual environment in $($pyenv)"
         & $python -m venv $pyenv
-        if($IsWindows) {
+        if ($IsWindows) {
             . (Join-Path $pyenv "Scripts" "Activate.ps1")
-        } else {
+        }
+        else {
             . (Join-Path $pyenv "bin" "Activate.ps1")
         }
-    } else {
+    }
+    else {
         Write-BuildLog "Virtual environment found."
     }
     # ensure that we are now in a virtual environment
@@ -318,26 +320,42 @@ task install-llvm-from-source -depends configure-sccache -postaction { Write-Cac
 }
 
 task package-musllinux-llvm -depends build-musllinux-container-image -preaction { Write-CacheStats } -postaction { Write-CacheStats } {
-    if ($IsLinux) {
-        $srcPath = $repo.root
-        $ioVolume = "$($srcPath):$($linux.musllinux_root)"
-        $userName = Get-LinuxContainerUserName
+    $srcPath = $repo.root
 
-        Invoke-LoggedCommand {
-            docker run --rm --user $userName -v $ioVolume -w "$($linux.musllinux_root)/qirlib" -e QIRLIB_PKG_DEST="$($linux.musllinux_root)/target" "$($linux.musllinux_tag)" cargo build --release --no-default-features --features package-llvm -vv
-        }
+    # For any of the volumes mapped, if the dir doesn't exist,
+    # docker will create it and it will be owned by root and
+    # the caching/install breaks with permission errors.
+    # New-Item is idempotent so we don't need to check for existence
+
+    $cacheMount, $cacheEnv = Get-CCacheParams
+
+    Write-BuildLog "Running container image: $($linux.musllinux_tag)"
+    $ioVolume = "$($srcPath):$($linux.musllinux_root)"
+    $userName = Get-LinuxContainerUserName
+    if (Test-CI) {
+        $userName = "root"
+    }
+    Invoke-LoggedCommand {
+        docker run --rm --user $userName -v $ioVolume @cacheMount @cacheEnv -w "$($linux.musllinux_root)" -e QIRLIB_PKG_DEST="$($linux.musllinux_root)/target/musllinux" "$($linux.musllinux_tag)" pwsh build.ps1 -t package-llvm
     }
 }
 
 task package-manylinux-llvm -depends build-manylinux-container-image -preaction { Write-CacheStats } -postaction { Write-CacheStats } {
-    if ($IsLinux) {
-        $srcPath = $repo.root
-        $ioVolume = "$($srcPath):$($linux.manylinux_root)"
-        $userName = Get-LinuxContainerUserName
+    $srcPath = $repo.root
 
-        Invoke-LoggedCommand {
-            docker run --rm --user $userName -v $ioVolume -w "$($linux.manylinux_root)/qirlib" -e QIRLIB_PKG_DEST="$($linux.manylinux_root)/target" "$($linux.manylinux_tag)" conda run --no-capture-output cargo build --release --no-default-features --features package-llvm -vv
-        }
+    # For any of the volumes mapped, if the dir doesn't exist,
+    # docker will create it and it will be owned by root and
+    # the caching/install breaks with permission errors.
+    # New-Item is idempotent so we don't need to check for existence
+
+    $cacheMount, $cacheEnv = Get-CCacheParams
+
+    Write-BuildLog "Running container image: $($linux.manylinux_tag)"
+    $ioVolume = "$($srcPath):$($linux.manylinux_root)"
+    $userName = Get-LinuxContainerUserName
+
+    Invoke-LoggedCommand {
+        docker run --rm --user $userName -v $ioVolume @cacheMount @cacheEnv -w "$($linux.manylinux_root)" -e QIRLIB_PKG_DEST="$($linux.manylinux_root)/target/manylinux" "$($linux.manylinux_tag)" conda run --no-capture-output pwsh build.ps1 -t package-llvm
     }
 }
 
@@ -350,9 +368,10 @@ task package-llvm {
         $clear_pkg_dest_var = $true
         $env:QIRLIB_PKG_DEST = Join-Path $repo.root "target"
     }
+    New-Item $env:QIRLIB_PKG_DEST -ItemType Directory -Force
     try {
         Invoke-LoggedCommand -wd $pyqir.qirlib.dir {
-            cargo build --release  --no-default-features --features package-llvm -vv
+            cargo build --release --no-default-features --features "package-llvm,$(Get-LLVMFeatureVersion)-no-llvm-linking" -vv
         }
     }
     finally {

--- a/eng/utils.ps1
+++ b/eng/utils.ps1
@@ -229,7 +229,7 @@ function Get-LLVMFeatureVersion {
     }
     else {
         # "llvm11-0", "llvm12-0", "llvm13-0", "llvm14-0"
-        "llvm11-0"
+        "llvm13-0"
     }
 }
 

--- a/notice.hbs
+++ b/notice.hbs
@@ -15,10 +15,10 @@ This work contains work released under the following licenses:
 
 
 {{/each}}{{/each}}
-LLVM 11.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
+LLVM 13.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
 https://github.com/llvm/llvm-project
 
-https://github.com/llvm/llvm-project/blob/llvmorg-11.1.0/llvm/LICENSE.TXT
+https://github.com/llvm/llvm-project/blob/llvmorg-13.0.1/llvm/LICENSE.TXT
 
 ==============================================================================
 The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/pyqir-evaluator/Cargo.toml
+++ b/pyqir-evaluator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-evaluator"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR Evaluation (JIT) library."

--- a/pyqir-evaluator/NOTICE-WHEEL.txt
+++ b/pyqir-evaluator/NOTICE-WHEEL.txt
@@ -9131,10 +9131,10 @@ SOFTWARE.
 
 
 
-LLVM 11.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
+LLVM 13.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
 https://github.com/llvm/llvm-project
 
-https://github.com/llvm/llvm-project/blob/llvmorg-11.1.0/llvm/LICENSE.TXT
+https://github.com/llvm/llvm-project/blob/llvmorg-13.0.1/llvm/LICENSE.TXT
 
 ==============================================================================
 The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/pyqir-evaluator/NOTICE-WHEEL.txt
+++ b/pyqir-evaluator/NOTICE-WHEEL.txt
@@ -9103,7 +9103,7 @@ SOFTWARE.
 
 
 
-pyqir-evaluator 0.4.2-alpha - SPDX: MIT - MIT License
+pyqir-evaluator 0.5.0-alpha - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir-evaluator/pyproject.toml
+++ b/pyqir-evaluator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir-evaluator"
-version = "0.4.2a1"
+version = "0.5.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir-generator/Cargo.toml
+++ b/pyqir-generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-generator"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR generator library."

--- a/pyqir-generator/NOTICE-WHEEL.txt
+++ b/pyqir-generator/NOTICE-WHEEL.txt
@@ -9131,10 +9131,10 @@ SOFTWARE.
 
 
 
-LLVM 11.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
+LLVM 13.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
 https://github.com/llvm/llvm-project
 
-https://github.com/llvm/llvm-project/blob/llvmorg-11.1.0/llvm/LICENSE.TXT
+https://github.com/llvm/llvm-project/blob/llvmorg-13.0.1/llvm/LICENSE.TXT
 
 ==============================================================================
 The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/pyqir-generator/NOTICE-WHEEL.txt
+++ b/pyqir-generator/NOTICE-WHEEL.txt
@@ -9103,7 +9103,7 @@ SOFTWARE.
 
 
 
-pyqir-generator 0.4.2-alpha - SPDX: MIT - MIT License
+pyqir-generator 0.5.0-alpha - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir-generator/pyproject.toml
+++ b/pyqir-generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir-generator"
-version = "0.4.2a1"
+version = "0.5.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir-generator/src/lib.rs
+++ b/pyqir-generator/src/lib.rs
@@ -9,7 +9,6 @@
 //     here since it's introduced by an upstream macro and not something
 //     we can directly control in our code.
 #![allow(clippy::needless_option_as_deref)]
-
 // This was introduced in 1.62, but we can't update the dependency to
 // to resolve it until we move to a newer version of python.
 #![allow(clippy::format_push_string)]

--- a/pyqir-generator/src/lib.rs
+++ b/pyqir-generator/src/lib.rs
@@ -10,5 +10,9 @@
 //     we can directly control in our code.
 #![allow(clippy::needless_option_as_deref)]
 
+// This was introduced in 1.62, but we can't update the dependency to
+// to resolve it until we move to a newer version of python.
+#![allow(clippy::format_push_string)]
+
 #[cfg(feature = "python-bindings")]
 pub mod python;

--- a/pyqir-parser/Cargo.toml
+++ b/pyqir-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-parser"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR parser library."

--- a/pyqir-parser/NOTICE-WHEEL.txt
+++ b/pyqir-parser/NOTICE-WHEEL.txt
@@ -5691,10 +5691,10 @@ SOFTWARE.
 
 
 
-LLVM 11.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
+LLVM 13.0 - Apache-2.0 WITH LLVM-exception - Apache License v2.0 with LLVM Exceptions
 https://github.com/llvm/llvm-project
 
-https://github.com/llvm/llvm-project/blob/llvmorg-11.1.0/llvm/LICENSE.TXT
+https://github.com/llvm/llvm-project/blob/llvmorg-13.0.1/llvm/LICENSE.TXT
 
 ==============================================================================
 The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/pyqir-parser/NOTICE-WHEEL.txt
+++ b/pyqir-parser/NOTICE-WHEEL.txt
@@ -5663,7 +5663,7 @@ SOFTWARE.
 
 
 
-pyqir-parser 0.4.2-alpha - SPDX: MIT - MIT License
+pyqir-parser 0.5.0-alpha - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir-parser/pyproject.toml
+++ b/pyqir-parser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir-parser"
-version = "0.4.2a1"
+version = "0.5.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir/pyproject.toml
+++ b/pyqir/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir"
-version = "0.4.2a1"
+version = "0.5.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir/setup.cfg
+++ b/pyqir/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyqir
-version = 0.4.2a1
+version = 0.5.0a1
 author = Microsoft
 license = MIT
 description = PyQIR - set of APIs for generating, parsing, and evaluating Quantum Intermediate Representation (QIR)
@@ -27,6 +27,6 @@ classifiers =
 [options]
 python_requires = >= 3.6
 install_requires =
-	pyqir-generator >= 0.4.2a1
-	pyqir-evaluator >= 0.4.2a1
- 	pyqir-parser >= 0.4.2a1
+	pyqir-generator >= 0.5.0a1
+	pyqir-evaluator >= 0.5.0a1
+ 	pyqir-parser >= 0.5.0a1

--- a/qirlib/Cargo.toml
+++ b/qirlib/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 readme = "README.md"
 homepage = "https://github.com/qir-alliance/pyqir"
 repository = "https://github.com/qir-alliance/pyqir"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 # We can't reference the disable-alltargets-init feature without including


### PR DESCRIPTION
This PR sets the default version of LLVM to 13. This is a breaking change for consumers of the QIR. This PR includes changes to:
- Version bumped to `0.5.0a1` as this is a breaking change.
- Pipeline
  - Default linux build agent is Ubuntu 22.04
  - Windows installs llvm 13 for build
- Documentation now references Ubuntu 22.04 so that default llvm/clang tooling is available for LLVM 13
- Build script initializes vscode and cargo config files for command line and editor tooling support.
- manylinux and musllinux install to separate target directories for isolation.