### PR TITLE
Bumping version to 0.6.0. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir-evaluator"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "pyo3",
  "qirlib",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir-generator"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "pyo3",
  "qirlib",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir-parser"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "inkwell",
  "llvm-ir",

--- a/eng/psakefile.ps1
+++ b/eng/psakefile.ps1
@@ -463,7 +463,8 @@ task run-examples {
     exec -workingDirectory $pyqir.generator.examples_dir {
         & $python -m pip install -U pip wheel
         & $python -m pip install -r requirements.txt
-        & $python -m pip install -U --no-index --find-links (Join-Path $repo.root "target" "wheels") pyqir-generator
+        & $python -m pip install -U --find-links (Join-Path $repo.root "target" "wheels") pyqir-generator
+
         & $python "bell_pair.py" | Tee-Object -Variable bell_pair_output
         $bell_first_line = $($bell_pair_output | Select-Object -first 1)
         $bell_expected = "; ModuleID = 'Bell'"

--- a/pyqir-evaluator/Cargo.toml
+++ b/pyqir-evaluator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-evaluator"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR Evaluation (JIT) library."

--- a/pyqir-evaluator/NOTICE-WHEEL.txt
+++ b/pyqir-evaluator/NOTICE-WHEEL.txt
@@ -9103,7 +9103,7 @@ SOFTWARE.
 
 
 
-pyqir-evaluator 0.5.0-alpha - SPDX: MIT - MIT License
+pyqir-evaluator 0.6.0-alpha - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir-evaluator/pyproject.toml
+++ b/pyqir-evaluator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir-evaluator"
-version = "0.5.0a1"
+version = "0.6.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir-generator/Cargo.toml
+++ b/pyqir-generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-generator"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR generator library."

--- a/pyqir-generator/NOTICE-WHEEL.txt
+++ b/pyqir-generator/NOTICE-WHEEL.txt
@@ -9103,7 +9103,7 @@ SOFTWARE.
 
 
 
-pyqir-generator 0.5.0-alpha - SPDX: MIT - MIT License
+pyqir-generator 0.6.0-alpha - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir-generator/pyproject.toml
+++ b/pyqir-generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir-generator"
-version = "0.5.0a1"
+version = "0.6.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir-parser/Cargo.toml
+++ b/pyqir-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Microsoft"]
 name = "pyqir-parser"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 edition = "2018"
 license = "MIT"
 description = "Python based QIR parser library."

--- a/pyqir-parser/NOTICE-WHEEL.txt
+++ b/pyqir-parser/NOTICE-WHEEL.txt
@@ -5663,7 +5663,7 @@ SOFTWARE.
 
 
 
-pyqir-parser 0.5.0-alpha - SPDX: MIT - MIT License
+pyqir-parser 0.6.0-alpha - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir-parser/pyproject.toml
+++ b/pyqir-parser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir-parser"
-version = "0.5.0a1"
+version = "0.6.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir/pyproject.toml
+++ b/pyqir/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir"
-version = "0.5.0a1"
+version = "0.6.0a1"
 requires-python = ">=3.6"
 
 [build-system]

--- a/pyqir/setup.cfg
+++ b/pyqir/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyqir
-version = 0.5.0a1
+version = 0.6.0a1
 author = Microsoft
 license = MIT
 description = PyQIR - set of APIs for generating, parsing, and evaluating Quantum Intermediate Representation (QIR)
@@ -27,6 +27,6 @@ classifiers =
 [options]
 python_requires = >= 3.6
 install_requires =
-	pyqir-generator >= 0.5.0a1
-	pyqir-evaluator >= 0.5.0a1
- 	pyqir-parser >= 0.5.0a1
+	pyqir-generator >= 0.6.0a1
+	pyqir-evaluator >= 0.6.0a1
+ 	pyqir-parser >= 0.6.0a1


### PR DESCRIPTION
Run-Examples now relies on the version in the repo being higher than pypi's published version.