### PR TITLE
Install Maturin with pip to avoid build breakage

### DIFF
--- a/eng/manylinux.Dockerfile
+++ b/eng/manylinux.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM quay.io/pypa/manylinux2014_x86_64 as base-with-rust
+FROM quay.io/pypa/manylinux2014_x86_64
 
 ARG USERNAME=runner
 ARG USER_UID=1000
@@ -29,23 +29,6 @@ RUN chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
 WORKDIR /io
 RUN chown ${USER_UID}:${USER_GID} /io
 
-FROM base-with-rust as builder
-
-ARG USERNAME=runner
-ARG USER_UID=1000
-ARG USER_GID=${USER_UID}
-
-USER $USERNAME
-
-# Temporary workaround installing beta for license/notice support
-RUN cargo install maturin --git https://github.com/PyO3/maturin --tag v0.12.12
-
-FROM base-with-rust
-
-ARG USERNAME=runner
-ARG USER_UID=1000
-ARG USER_GID=${USER_UID}
-
 USER $USERNAME
 
 # Add all supported python versions
@@ -57,7 +40,7 @@ RUN python3.6 -m pip install --no-cache-dir cffi \
     && python3.9 -m pip install --no-cache-dir cffi \
     && python3.10 -m pip install --no-cache-dir cffi
 
-COPY --from=builder ${CARGO_HOME}/bin/maturin /usr/bin/maturin
+RUN python3.10 -m pip install --no-cache-dir maturin==0.12.12
 
 USER root
 

--- a/eng/musllinux.Dockerfile
+++ b/eng/musllinux.Dockerfile
@@ -6,7 +6,7 @@
 # 3.15 has llvm/clang 12.0.1
 # edge has llvm/13.0.1
 
-FROM python:3.6-alpine3.14 as base
+FROM python:3.6-alpine3.14
 
 ARG USERNAME=runner
 ARG USER_UID=1000
@@ -28,11 +28,6 @@ RUN chmod 0440 /etc/sudoers.d/${USERNAME}
 WORKDIR /oi
 RUN chown ${USER_UID}:${USER_GID} /oi
 
-FROM base as base-with-rust
-
-ARG USERNAME=runner
-ARG RUST_VERSION=1.57.0
-
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:${PATH} \
@@ -52,19 +47,6 @@ RUN chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
     rustup --version; \
     cargo --version; \
     rustc --version;
-
-FROM base-with-rust as builder
-
-ARG USERNAME=runner
-
-USER $USERNAME
-
-# Temporary workaround installing beta for license/notice support
-RUN cargo install maturin --git https://github.com/PyO3/maturin --tag v0.12.12
-
-FROM base-with-rust
-
-ARG USERNAME=runner
 
 USER root
 
@@ -111,9 +93,7 @@ RUN apk add patchelf
 USER $USERNAME
 
 RUN python -m pip install -U pip
-RUN python -m pip install --no-cache-dir cffi
-
-COPY --from=builder ${CARGO_HOME}/bin/maturin /usr/bin/maturin
+RUN python -m pip install --no-cache-dir cffi maturin==0.12.12
 
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV

--- a/eng/musllinuxCI.Dockerfile
+++ b/eng/musllinuxCI.Dockerfile
@@ -6,15 +6,11 @@
 # 3.15 has llvm/clang 12.0.1
 # edge has llvm/13.0.1
 
-FROM python:3.6-alpine3.14 as base
+FROM python:3.6-alpine3.14
 
 ARG RUST_VERSION=1.57.0
 
 WORKDIR /oi
-
-FROM base as base-with-rust
-
-ARG RUST_VERSION=1.57.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -35,13 +31,6 @@ RUN chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
     rustup --version; \
     cargo --version; \
     rustc --version;
-
-FROM base-with-rust as builder
-
-# Temporary workaround installing beta for license/notice support
-RUN cargo install maturin --git https://github.com/PyO3/maturin --tag v0.12.12
-
-FROM base-with-rust
 
 RUN apk add samurai
 
@@ -84,9 +73,7 @@ RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 RUN apk add patchelf
 
 RUN python -m pip install -U pip
-RUN python -m pip install --no-cache-dir cffi
-
-COPY --from=builder ${CARGO_HOME}/bin/maturin /usr/bin/maturin
+RUN python -m pip install --no-cache-dir cffi maturin==0.12.12
 
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV

--- a/eng/psakefile.ps1
+++ b/eng/psakefile.ps1
@@ -258,8 +258,8 @@ task check-environment {
 }
 
 task init -depends check-environment {
-    if ((Test-CI)) {
-        cargo install maturin --git https://github.com/PyO3/maturin --tag v0.12.12
+    if (Test-CI) {
+        & $python -m pip install maturin==0.12.12
     }
 
     $env:CARGO_EXTRA_ARGS = "-vv --features `"$(Get-LLVMFeatureVersion)`""


### PR DESCRIPTION
This build step is failing:

```dockerfile
RUN cargo install maturin --git https://github.com/PyO3/maturin --tag v0.12.12
```

because a recently released version of the `time` dependency no longer supports rustc 1.57:

```
error: failed to compile `maturin v0.12.12 (https://github.com/PyO3/maturin?tag=v0.12.12#3f490a1d)`, intermediate artifacts can be found at `/tmp/cargo-installisSKVr`

Caused by:
  package `time v0.3.14` cannot be built because it requires rustc 1.59.0 or newer, while the currently active rustc version is 1.57.0
The command '/bin/sh -c cargo install maturin --git https://github.com/PyO3/maturin --tag v0.12.12' returned a non-zero code: 101
```

The recommended way to install Maturin seems to be with pip, which avoids this issue, so I updated the Dockerfiles.