### PR TITLE
Improve Sphinx documentation for PyQIR Generator

### DIFF
--- a/docs/api-reference/evaluator.md
+++ b/docs/api-reference/evaluator.md
@@ -1,28 +1,15 @@
-# pyqir.evaluator
-
-## `NonadaptiveEvaluator` class
+# Evaluator
 
 ```{eval-rst}
 .. autoclass:: pyqir.evaluator.NonadaptiveEvaluator
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :members:
 
-## `GateSet` class
-
-```{eval-rst}
 .. autoclass:: pyqir.evaluator.GateSet
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :members:
+   :undoc-members:
 
-## `GateLogger` class
-
-```{eval-rst}
 .. autoclass:: pyqir.evaluator.GateLogger
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :show-inheritance:
+   :members:
+   :undoc-members:
 ```

--- a/docs/api-reference/generator.md
+++ b/docs/api-reference/generator.md
@@ -1,42 +1,46 @@
-# pyqir.generator
+# Generator
 
 ## Modules
 
 ```{eval-rst}
 .. autoclass:: pyqir.generator.SimpleModule
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :members:
 ```
 
 ## Builders
 
 ```{eval-rst}
 .. autoclass:: pyqir.generator.Builder
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :members:
+
+.. autoclass:: pyqir.generator.BasicQisBuilder
+   :members:
+
+.. autoenum:: pyqir.generator.IntPredicate
 ```
 
+## Types
+
 ```{eval-rst}
-.. autoclass:: pyqir.generator.BasicQisBuilder
-    :show-inheritance:
-    :members:
-    :undoc-members:
+.. automodule:: pyqir.generator.types
+   :members:
 ```
 
 ## Values
 
 ```{eval-rst}
-.. autoclass:: pyqir.generator.Qubit
-    :show-inheritance:
-    :members:
-    :undoc-members:
+.. autoclass:: pyqir.generator.Function
+   :members:
+
+.. autoclass:: pyqir.generator.Value
+   :members:
+
+.. autofunction:: pyqir.generator.const
 ```
 
+## IR and bitcode
+
 ```{eval-rst}
-.. autoclass:: pyqir.generator.Ref
-    :show-inheritance:
-    :members:
-    :undoc-members:
+.. autofunction:: pyqir.generator.ir_to_bitcode
+.. autofunction:: pyqir.generator.bitcode_to_ir
 ```

--- a/docs/api-reference/parser.md
+++ b/docs/api-reference/parser.md
@@ -1,352 +1,262 @@
-# pyqir.parser
+# Parser
 
 ## Classes representing QIR types
 
 ```{eval-rst}
 .. autoclass:: pyqir.parser.QirType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirVoidType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirIntegerType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirPointerType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirDoubleType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirArrayType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirStructType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirNamedStructType
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirResultType
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :show-inheritance:
+   :members:
+   :undoc-members:
 ```
 
 ## Classes representing QIR operands
 
 ```{eval-rst}
 .. autoclass:: pyqir.parser.QirOperand
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirLocalOperand
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirIntConstant
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirDoubleConstant
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirNullConstant
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirQubitConstant
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirResultConstant
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :show-inheritance:
+   :members:
+   :undoc-members:
 ```
 
 ## Classes representing basic block terminators
 
 ```{eval-rst}
 .. autoclass:: pyqir.parser.QirTerminator
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirRetTerminator
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirBrTerminator
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirCondBrTerminator
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirSwitchTerminator
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirUnreachableTerminator
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :show-inheritance:
+   :members:
+   :undoc-members:
 ```
 
 ## Classes representing QIR instructions
 
 ```{eval-rst}
 .. autoclass:: pyqir.parser.QirInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirQisCallInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirRtCallInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirQirCallInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirCallInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirAddInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirSubInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirMulInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirUDivInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirSDivInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirURemInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirSRemInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirAndInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirOrInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirXorInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirShlInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirLShrInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirAShrInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFAddInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFSubInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFMulInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFDivInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFRemInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFNegInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirICmpInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirFCmpInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
-```
+   :show-inheritance:
+   :members:
+   :undoc-members:
 
-```{eval-rst}
 .. autoclass:: pyqir.parser.QirPhiInstr
-    :show-inheritance:
-    :members:
-    :undoc-members:
+   :show-inheritance:
+   :members:
+   :undoc-members:
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,42 +12,45 @@
 #
 # import os
 # import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+# sys.path.insert(0, os.path.abspath("."))
 
 # -- Project information -----------------------------------------------------
 
-project = 'PyQIR'
-copyright = '2021, QIR Alliance'
-author = 'QIR Alliance'
-
+project = "PyQIR"
+copyright = "2021, QIR Alliance"
+author = "QIR Alliance"
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
 extensions = [
-    'enum_tools.autoenum',
-    'myst_parser',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-]
-myst_enable_extensions = [
-    'colon_fence',
+    "enum_tools.autoenum",
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
 ]
 
+myst_enable_extensions = [
+    "colon_fence",
+]
+
+autodoc_type_aliases = {
+    "Type": "Type",
+}
+
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
-    'sphinx': ('https://www.sphinx-doc.org/en/master', None),
-    'myst-parser': ('https://myst-parser.readthedocs.io/en/latest/', None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
+    "myst-parser": ("https://myst-parser.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------
@@ -55,9 +58,9 @@ intersphinx_mapping = {
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,12 +28,13 @@ author = 'QIR Alliance'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "myst_parser",
-    "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx"
+    'enum_tools.autoenum',
+    'myst_parser',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
 ]
 myst_enable_extensions = [
-    "colon_fence"
+    'colon_fence',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -46,7 +47,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 intersphinx_mapping = {
     'sphinx': ('https://www.sphinx-doc.org/en/master', None),
-    'myst-parser': ('https://myst-parser.readthedocs.io/en/latest/', None)
+    'myst-parser': ('https://myst-parser.readthedocs.io/en/latest/', None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/eng/docs-requirements.txt
+++ b/eng/docs-requirements.txt
@@ -1,2 +1,3 @@
-sphinx
+enum-tools[sphinx]
 myst-parser
+sphinx

--- a/eng/psakefile.ps1
+++ b/eng/psakefile.ps1
@@ -63,9 +63,11 @@ include utils.ps1
 
 task default -depends qirlib, pyqir-tests, parser, generator, evaluator, metawheel, run-examples
 
-task manylinux -depends build-manylinux-container-image, run-manylinux-container-image, run-examples-in-containers 
+task build -depends qirlib, generator, evaluator, parser
 
 task checks -depends cargo-fmt, cargo-clippy, mypy
+
+task manylinux -depends build-manylinux-container-image, run-manylinux-container-image, run-examples-in-containers 
 
 task run-manylinux-container-image -preaction { Write-CacheStats } -postaction { Write-CacheStats } {
     $srcPath = $repo.root
@@ -147,7 +149,7 @@ task metawheel {
 
 task wheelhouse `
     -precondition { -not (Test-Path $wheelhouse -ErrorAction SilentlyContinue) } `
-{ Invoke-Task rebuild }
+{ Invoke-Task build }
 
 task docs -depends wheelhouse {
     # Write out the wheels available

--- a/eng/utils.ps1
+++ b/eng/utils.ps1
@@ -291,7 +291,7 @@ function Create-PyEnv() {
     try {
         pip install -r $RequirementsPath
         foreach ($artifact in $ArtifactPaths) {
-            pip install $artifact
+            pip install --force-reinstall $artifact
         }
     }
     finally {

--- a/pyqir-generator/pyqir/generator/_native.pyi
+++ b/pyqir-generator/pyqir/generator/_native.pyi
@@ -6,392 +6,116 @@ from pyqir.generator.types import Type
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 
+class Function:
+    ...
+
+
+class Value:
+    ...
+
+
+def const(ty: Type, value: Union[int, float]) -> Value: ...
+
+
+class Builder:
+    def and_(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def or_(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def xor(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def add(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def sub(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def mul(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def shl(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def lshr(self, lhs: Value, rhs: Value) -> Value: ...
+
+    def icmp(self, pred: IntPredicate, lhs: Value, rhs: Value) -> Value: ...
+
+    def call(
+        self,
+        function: Function,
+        args: Sequence[Union[Value, bool, int, float]],
+    ) -> Optional[Value]:
+        ...
+
+    def if_(
+        self, cond: Value, true: Callable[[], None] = ..., false: Callable[[], None] = ...
+    ) -> None:
+        ...
+
+
+class SimpleModule:
+    def __init__(
+        self, name: str, num_qubits: int, num_results: int
+    ) -> None:
+        ...
+
+    @property
+    def qubits(self) -> Tuple[Value, ...]: ...
+
+    @property
+    def results(self) -> Tuple[Value, ...]: ...
+
+    @property
+    def builder(self) -> Builder: ...
+
+    def ir(self) -> str: ...
+
+    def bitcode(self) -> bytes: ...
+
+    def add_external_function(self, name: str, ty: Type) -> Function: ...
+
+
+class BasicQisBuilder:
+    def __init__(self, builder: Builder) -> None: ...
+
+    def cx(self, control: Value, target: Value) -> None: ...
+
+    def cz(self, control: Value, target: Value) -> None: ...
+
+    def h(self, qubit: Value) -> None: ...
+
+    def mz(self, qubit: Value, result: Value) -> None: ...
+
+    def reset(self, qubit: Value) -> None: ...
+
+    def rx(self, theta: Union[Value, float], qubit: Value) -> None: ...
+
+    def ry(self, theta: Union[Value, float], qubit: Value) -> None: ...
+
+    def rz(self, theta: Union[Value, float], qubit: Value) -> None: ...
+
+    def s(self, qubit: Value) -> None: ...
+
+    def s_adj(self, qubit: Value) -> None: ...
+
+    def t(self, qubit: Value) -> None: ...
+
+    def t_adj(self, qubit: Value) -> None: ...
+
+    def x(self, qubit: Value) -> None: ...
+
+    def y(self, qubit: Value) -> None: ...
+
+    def z(self, qubit: Value) -> None: ...
+
+    def if_result(
+        self, result: Value, one: Callable[[], None] = ..., zero: Callable[[], None] = ...
+    ) -> None: ...
+
+
 def ir_to_bitcode(
     ir: str, module_name: Optional[str] = ..., source_file_name: Optional[str] = ...
 ) -> bytes:
-    """
-    Converts the supplied QIR string to its bitcode equivalent.
-
-    :param ir: The QIR string to convert
-    :param module_name: The name of the QIR module, default is "" if None
-    :param source_file_name: The source file name of the QIR module. Unchanged if None
-    :return: The equivalent bitcode as bytes.
-    """
     ...
 
 
 def bitcode_to_ir(
     bitcode: bytes, module_name: Optional[str] = ..., source_file_name: Optional[str] = ...
 ) -> str:
-    """
-    Converts the supplied bitcode to its QIR string equivalent.
-
-    :param ir: The bitcode bytes to convert
-    :param module_name: The name of the QIR module, default is "" if None
-    :param source_file_name: The source file name of the QIR module. Unchanged if None
-    :return: The equivalent QIR string.
-    """
     ...
-
-
-class Function:
-    """A QIR function."""
-    ...
-
-
-class Value:
-    """A QIR value."""
-    ...
-
-
-def const(ty: Type, value: Union[int, float]) -> Value:
-    """
-    Creates a constant QIR value.
-
-    :param ty: The type of the value.
-    :param value: A Python value that will be converted into a QIR value.
-    :returns: The constant QIR value.
-    """
-    ...
-
-
-class Builder:
-    """An instruction builder."""
-
-    def and_(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a bitwise logical and instruction.
-
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :returns: The result.
-        """
-        ...
-
-    def or_(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a bitwise logical or instruction.
-
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :returns: The result.
-        """
-        ...
-
-    def xor(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a bitwise logical exclusive or instruction.
-
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :returns: The result.
-        """
-        ...
-
-    def add(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts an addition instruction.
-
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :returns: The sum.
-        """
-        ...
-
-    def sub(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a subtraction instruction.
-
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :returns: The difference.
-        """
-        ...
-
-    def mul(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a multiplication instruction.
-
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :returns: The product.
-        """
-        ...
-
-    def shl(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a shift left instruction.
-
-        :param lhs: The value to shift.
-        :param rhs: The number of bits to shift by.
-        :returns: The result.
-        """
-        ...
-
-    def lshr(self, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts a logical (zero fill) shift right instruction.
-
-        :param lhs: The value to shift.
-        :param rhs: The number of bits to shift by.
-        :returns: The result.
-        """
-        ...
-
-    def icmp(self, pred: IntPredicate, lhs: Value, rhs: Value) -> Value:
-        """
-        Inserts an integer comparison instruction.
-
-        :param pred: The predicate to compare by.
-        :param lhs: The left-hand side.
-        :param rhs: The right-hand side.
-        :return: The boolean result.
-        """
-        ...
-
-    def call(
-        self,
-        function: Function,
-        args: Sequence[Union[Value, bool, int, float]]
-    ) -> Optional[Value]:
-        """
-        Inserts a call instruction.
-
-        :param function: The function to call.
-        :param args: The arguments to the function.
-        :returns: The return value, or None if the function has a void return type.
-        """
-        ...
-
-    def if_(self, cond: Value, true: Callable[[], None] = ..., false: Callable[[], None] = ...) -> None:
-        """
-        Inserts a branch conditioned on a boolean.
-
-        Instructions inserted when ``true`` is called will be inserted into the
-        true branch. Instructions inserted when ``false`` is called will be
-        inserted into the false branch. The true and false callables should use
-        this module's builder to build instructions.
-
-        :param cond: The boolean condition to branch on.
-        :param true: A callable that inserts instructions for the branch where
-                     the condition is true.
-        :param false: A callable that inserts instructions for the branch where
-                      the condition is false.
-        """
-        ...
-
-
-class SimpleModule:
-    """
-    A simple module represents an executable QIR program with these
-    restrictions:
-
-    - There is one global qubit register and one global result register. Both
-      are statically allocated with a fixed size.
-    - There is only a single function that runs as the entry point.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        num_qubits: int,
-        num_results: int,
-    ) -> None:
-        """
-        Initializes the module.
-
-        :param name: The name of the module.
-        :param num_qubits: The number of statically allocated qubits.
-        :param num_results: The number of statically allocated results.
-        """
-        ...
-
-    @property
-    def qubits(self) -> Tuple[Value, ...]:
-        """The global qubit register."""
-        ...
-
-    @property
-    def results(self) -> Tuple[Value, ...]:
-        """The global result register."""
-        ...
-
-    @property
-    def builder(self) -> Builder:
-        """The instruction builder."""
-        ...
-
-    def ir(self) -> str:
-        """Emits the LLVM IR for the module as plain text."""
-        ...
-
-    def bitcode(self) -> bytes:
-        """Emits the LLVM bitcode for the module as a sequence of bytes."""
-        ...
-
-    def add_external_function(self, name: str, ty: Type) -> Function:
-        """
-        Adds a declaration for an externally linked function to the module.
-
-        :param name: The name of the function.
-        :param ty: The type of the function.
-        :return: The function value.
-        """
-        ...
-
-
-class BasicQisBuilder:
-    """
-    An instruction builder that generates instructions from the basic quantum
-    instruction set.
-    """
-
-    def __init__(self, builder: Builder) -> None:
-        """
-        Initializes a new basic QIS instruction builder that wraps the given
-        builder.
-        """
-        ...
-
-    def cx(self, control: Value, target: Value) -> None:
-        """
-        Inserts a controlled Pauli :math:`X` gate.
-
-        :param control: The control qubit.
-        :param target: The target qubit.
-        """
-        ...
-
-    def cz(self, control: Value, target: Value) -> None:
-        """
-        Inserts a controlled Pauli :math:`Z` gate.
-
-        :param control: The control qubit.
-        :param target: The target qubit.
-        """
-        ...
-
-    def h(self, qubit: Value) -> None:
-        """
-        Inserts a Hadamard gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def mz(self, qubit: Value, result: Value) -> None:
-        """
-        Inserts a Z-basis measurement operation.
-
-        :param qubit: The qubit to measure.
-        :param result: A result where the measurement result will be written to.
-        """
-        ...
-
-    def reset(self, qubit: Value) -> None:
-        """
-        Inserts a reset operation.
-
-        :param qubit: The qubit to reset.
-        """
-        ...
-
-    def rx(self, theta: Union[Value, float], qubit: Value) -> None:
-        """
-        Inserts a rotation gate about the :math:`x` axis.
-
-        :param theta: The angle to rotate by.
-        :param qubit: The qubit to rotate.
-        """
-        ...
-
-    def ry(self, theta: Union[Value, float], qubit: Value) -> None:
-        """
-        Inserts a rotation gate about the :math:`y` axis.
-
-        :param theta: The angle to rotate by.
-        :param qubit: The qubit to rotate.
-        """
-        ...
-
-    def rz(self, theta: Union[Value, float], qubit: Value) -> None:
-        """
-        Inserts a rotation gate about the :math:`z` axis.
-
-        :param theta: The angle to rotate by.
-        :param qubit: The qubit to rotate.
-        """
-        ...
-
-    def s(self, qubit: Value) -> None:
-        """
-        Inserts an :math:`S` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def s_adj(self, qubit: Value) -> None:
-        """
-        Inserts an adjoint :math:`S` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def t(self, qubit: Value) -> None:
-        """
-        Inserts a :math:`T` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def t_adj(self, qubit: Value) -> None:
-        """
-        Inserts an adjoint :math:`T` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def x(self, qubit: Value) -> None:
-        """
-        Inserts a Pauli :math:`X` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def y(self, qubit: Value) -> None:
-        """
-        Inserts a Pauli :math:`Y` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def z(self, qubit: Value) -> None:
-        """
-        Inserts a Pauli :math:`Z` gate.
-
-        :param qubit: The target qubit.
-        """
-        ...
-
-    def if_result(self, result: Value, one: Callable[[], None] = ..., zero: Callable[[], None] = ...) -> None:
-        """
-        Inserts a branch conditioned on a measurement result.
-
-        Instructions inserted when ``one`` is called will be inserted into the
-        one branch. Instructions inserted when ``zero`` is called will be
-        inserted into the zero branch. The one and zero callables should use
-        this module's builder to build instructions.
-
-        :param cond: The result condition to branch on.
-        :param one: A callable that inserts instructions for the branch where
-                    the result is one.
-        :param zero: A callable that inserts instructions for the branch where
-                     the result is zero.
-        """
-        ...

--- a/pyqir-generator/src/python.rs
+++ b/pyqir-generator/src/python.rs
@@ -24,32 +24,6 @@ use qirlib::generation::{
 };
 use std::{cell::RefCell, vec};
 
-#[pyfunction]
-#[allow(clippy::needless_pass_by_value)]
-fn ir_to_bitcode<'a>(
-    py: Python<'a>,
-    value: &str,
-    module_name: Option<String>,
-    source_file_name: Option<String>,
-) -> PyResult<&'a PyBytes> {
-    let bitcode = qirlib::generation::ir_to_bitcode(value, &module_name, &source_file_name)
-        .map_err(PyOSError::new_err)?;
-    Ok(PyBytes::new(py, &bitcode))
-}
-
-#[pyfunction]
-#[allow(clippy::needless_pass_by_value)]
-fn bitcode_to_ir<'a>(
-    py: Python<'a>,
-    value: &PyBytes,
-    module_name: Option<String>,
-    source_file_name: Option<String>,
-) -> PyResult<&'a PyString> {
-    let ir = qirlib::generation::bitcode_to_ir(value.as_bytes(), &module_name, &source_file_name)
-        .map_err(PyOSError::new_err)?;
-    Ok(PyUnicode::new(py, ir.as_str()))
-}
-
 #[pymodule]
 #[pyo3(name = "_native")]
 fn native_module(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -162,6 +136,7 @@ impl<'source> FromPyObject<'source> for PyIntPredicate {
     }
 }
 
+/// A QIR function.
 #[derive(Clone)]
 #[pyclass]
 struct Function {
@@ -169,6 +144,7 @@ struct Function {
     ty: Type,
 }
 
+/// A QIR value.
 #[derive(Clone)]
 #[pyclass]
 struct Value(interop::Value);
@@ -189,7 +165,14 @@ impl PyObjectProtocol for Value {
     }
 }
 
+/// Creates a constant QIR value.
+///
+/// :param Type ty: The type of the value.
+/// :param Union[int, float] value: A Python value that will be converted into a QIR value.
+/// :returns: The constant QIR value.
+/// :rtype: Value
 #[pyfunction]
+#[pyo3(text_signature = "(ty, value)")]
 #[allow(clippy::needless_pass_by_value)]
 fn constant(ty: PyType, value: &PyAny) -> PyResult<Value> {
     match ty {
@@ -202,6 +185,7 @@ fn constant(ty: PyType, value: &PyAny) -> PyResult<Value> {
     .map(Value)
 }
 
+/// An instruction builder.
 #[pyclass]
 struct Builder {
     external_functions: Vec<Function>,
@@ -211,52 +195,114 @@ struct Builder {
 
 #[pymethods]
 impl Builder {
-    #[new]
-    fn new() -> Builder {
-        Builder {
-            external_functions: vec![],
-            next_variable: RefCell::new(Variable::new()),
-            frames: RefCell::new(vec![vec![]]),
-        }
-    }
-
+    /// Inserts a bitwise logical and instruction.
+    ///
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :returns: The result.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn and_(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::And, lhs.0, rhs.0)
     }
 
+    /// Inserts a bitwise logical or instruction.
+    ///
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :returns: The result.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn or_(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::Or, lhs.0, rhs.0)
     }
 
+    /// Inserts a bitwise logical exclusive or instruction.
+    ///
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :returns: The result.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn xor(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::Xor, lhs.0, rhs.0)
     }
 
+    /// Inserts an addition instruction.
+    ///
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :returns: The sum.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn add(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::Add, lhs.0, rhs.0)
     }
 
+    /// Inserts a subtraction instruction.
+    ///
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :returns: The difference.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn sub(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::Sub, lhs.0, rhs.0)
     }
 
+    /// Inserts a multiplication instruction.
+    ///
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :returns: The product.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn mul(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::Mul, lhs.0, rhs.0)
     }
 
+    /// Inserts a shift left instruction.
+    ///
+    /// :param Value lhs: The value to shift.
+    /// :param Value rhs: The number of bits to shift by.
+    /// :returns: The result.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn shl(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::Shl, lhs.0, rhs.0)
     }
 
+    /// Inserts a logical (zero fill) shift right instruction.
+    ///
+    /// :param Value lhs: The value to shift.
+    /// :param Value rhs: The number of bits to shift by.
+    /// :returns: The result.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, lhs, rhs)")]
     fn lshr(&self, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::LShr, lhs.0, rhs.0)
     }
 
+    /// Inserts an integer comparison instruction.
+    ///
+    /// :param IntPredicate pred: The predicate to compare by.
+    /// :param Value lhs: The left-hand side.
+    /// :param Value rhs: The right-hand side.
+    /// :return: The boolean result.
+    /// :rtype: Value
+    #[pyo3(text_signature = "(self, pred, lhs, rhs)")]
     #[allow(clippy::needless_pass_by_value)]
     fn icmp(&self, pred: PyIntPredicate, lhs: Value, rhs: Value) -> Value {
         self.push_binary_op(BinaryKind::ICmp(pred.0), lhs.0, rhs.0)
     }
 
+    /// Inserts a call instruction.
+    ///
+    /// :param Function function: The function to call.
+    /// :param Sequence[Union[Value, bool, int, float]] args: The arguments to the function.
+    /// :returns: The return value, or None if the function has a void return type.
+    /// :rtype: Optional[Value]
+    #[pyo3(text_signature = "(self, function, args)")]
     fn call(&self, function: Function, args: &PySequence) -> PyResult<Option<Value>> {
         let (param_types, return_type) = match function.ty {
             Type::Function { params, result } => (params, result),
@@ -290,6 +336,18 @@ impl Builder {
         Ok(result.map(|v| Value(interop::Value::Variable(v))))
     }
 
+    /// Inserts a branch conditioned on a boolean.
+    ///
+    /// Instructions inserted when ``true`` is called will be inserted into the true branch.
+    /// Instructions inserted when ``false`` is called will be inserted into the false branch. The
+    /// true and false callables should use this module's builder to build instructions.
+    ///
+    /// :param Value cond: The boolean condition to branch on.
+    /// :param Callable[[], None] true:
+    ///     A callable that inserts instructions for the branch where the condition is true.
+    /// :param Callable[[], None] false:
+    ///     A callable that inserts instructions for the branch where the condition is false.
+    #[pyo3(text_signature = "(self, cond, true, false)")]
     fn if_(&self, cond: Value, r#true: Option<&PyAny>, r#false: Option<&PyAny>) -> PyResult<()> {
         let if_ = If {
             cond: cond.0,
@@ -302,6 +360,14 @@ impl Builder {
 }
 
 impl Builder {
+    fn new() -> Builder {
+        Builder {
+            external_functions: vec![],
+            next_variable: RefCell::new(Variable::new()),
+            frames: RefCell::new(vec![vec![]]),
+        }
+    }
+
     fn push_inst(&self, inst: Instruction) {
         self.frames.borrow_mut().last_mut().unwrap().push(inst);
     }
@@ -333,7 +399,17 @@ impl Builder {
     }
 }
 
+/// A simple module represents an executable QIR program with these restrictions:
+///
+/// - There is one global qubit register and one global result register. Both are statically
+///   allocated with a fixed size.
+/// - There is only a single function that runs as the entry point.
+///
+/// :param str name: The name of the module.
+/// :param int num_qubits: The number of statically allocated qubits.
+/// :param int num_results: The number of statically allocated results.
 #[pyclass]
+#[pyo3(text_signature = "(name, num_qubits, num_results)")]
 struct SimpleModule {
     model: SemanticModel,
     builder: Py<Builder>,
@@ -359,6 +435,9 @@ impl SimpleModule {
         })
     }
 
+    /// The global qubit register.
+    ///
+    /// :type: Tuple[Value, ...]
     #[getter]
     fn qubits(&self) -> Vec<Value> {
         (0..self.num_qubits)
@@ -366,6 +445,9 @@ impl SimpleModule {
             .collect()
     }
 
+    /// The global result register.
+    ///
+    /// :type: Tuple[Value, ...]
     #[getter]
     fn results(&self) -> Vec<Value> {
         (0..self.num_results)
@@ -373,16 +455,25 @@ impl SimpleModule {
             .collect()
     }
 
+    /// The instruction builder.
+    ///
+    /// :type: Builder
     #[getter]
     fn builder(&self) -> Py<Builder> {
         self.builder.clone()
     }
 
+    /// Emits the LLVM IR for the module as plain text.
+    ///
+    /// :rtype: str
     fn ir(&self, py: Python) -> PyResult<String> {
         let model = self.model_from_builder(py);
         emit::ir(&model).map_err(PyOSError::new_err)
     }
 
+    /// Emits the LLVM bitcode for the module as a sequence of bytes.
+    ///
+    /// :rtype: bytes
     fn bitcode<'a>(&self, py: Python<'a>) -> PyResult<&'a PyBytes> {
         let model = self.model_from_builder(py);
         match emit::bitcode(&model) {
@@ -391,6 +482,13 @@ impl SimpleModule {
         }
     }
 
+    /// Adds a declaration for an externally linked function to the module.
+    ///
+    /// :param str name: The name of the function.
+    /// :param Type ty: The type of the function.
+    /// :return: The function value.
+    /// :rtype: Function
+    #[pyo3(text_signature = "(self, name, ty)")]
     fn add_external_function(&mut self, py: Python, name: String, ty: PyType) -> Function {
         let mut builder = self.builder.as_ref(py).borrow_mut();
         let ty = ty.into();
@@ -429,7 +527,11 @@ fn build_frame(builder: &Builder, callback: Option<&PyAny>) -> PyResult<Vec<Inst
     Ok(builder.pop_frame().unwrap())
 }
 
+/// An instruction builder that generates instructions from the basic quantum instruction set.
+///
+/// :param Builder builder: The underlying builder used to build QIS instructions.
 #[pyclass]
+#[pyo3(text_signature = "(builder)")]
 struct BasicQisBuilder {
     builder: Py<Builder>,
 }
@@ -441,31 +543,65 @@ impl BasicQisBuilder {
         BasicQisBuilder { builder }
     }
 
+    /// Inserts a controlled Pauli :math:`X` gate.
+    ///
+    /// :param Value control: The control qubit.
+    /// :param Value target: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, control, target)")]
     fn cx(&self, py: Python, control: Value, target: Value) {
         let controlled = Controlled::new(control.0, target.0);
         self.push_inst(py, Instruction::Cx(controlled));
     }
 
+    /// Inserts a controlled Pauli :math:`Z` gate.
+    ///
+    /// :param Value control: The control qubit.
+    /// :param Value target: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, control, target)")]
     fn cz(&self, py: Python, control: Value, target: Value) {
         let controlled = Controlled::new(control.0, target.0);
         self.push_inst(py, Instruction::Cz(controlled));
     }
 
+    /// Inserts a Hadamard gate.
+    ///
+    /// :param qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn h(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::H(single));
     }
 
+    /// Inserts a Z-basis measurement operation.
+    ///
+    /// :param Value qubit: The qubit to measure.
+    /// :param Value result: A result where the measurement result will be written to.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit, result)")]
     fn mz(&self, py: Python, qubit: Value, result: Value) {
         let measured = Measured::new(qubit.0, result.0);
         self.push_inst(py, Instruction::M(measured));
     }
 
+    /// Inserts a reset operation.
+    ///
+    /// :param Value qubit: The qubit to reset.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn reset(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::Reset(single));
     }
 
+    /// Inserts a rotation gate about the :math:`x` axis.
+    ///
+    /// :param Union[Value, float] theta: The angle to rotate by.
+    /// :param Value qubit: The qubit to rotate.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, theta, qubit)")]
     fn rx(&self, py: Python, theta: &PyAny, qubit: Value) -> PyResult<()> {
         let theta = extract_value(&Type::Double, theta)?;
         let rotated = Rotated::new(theta, qubit.0);
@@ -473,6 +609,12 @@ impl BasicQisBuilder {
         Ok(())
     }
 
+    /// Inserts a rotation gate about the :math:`y` axis.
+    ///
+    /// :param Union[Value, float] theta: The angle to rotate by.
+    /// :param Value qubit: The qubit to rotate.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, theta, qubit)")]
     fn ry(&self, py: Python, theta: &PyAny, qubit: Value) -> PyResult<()> {
         let theta = extract_value(&Type::Double, theta)?;
         let rotated = Rotated::new(theta, qubit.0);
@@ -480,6 +622,12 @@ impl BasicQisBuilder {
         Ok(())
     }
 
+    /// Inserts a rotation gate about the :math:`z` axis.
+    ///
+    /// :param Union[Value, float] theta: The angle to rotate by.
+    /// :param Value qubit: The qubit to rotate.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, theta, qubit)")]
     fn rz(&self, py: Python, theta: &PyAny, qubit: Value) -> PyResult<()> {
         let theta = extract_value(&Type::Double, theta)?;
         let rotated = Rotated::new(theta, qubit.0);
@@ -487,41 +635,89 @@ impl BasicQisBuilder {
         Ok(())
     }
 
+    /// Inserts an :math:`S` gate.
+    ///
+    /// :param Value qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn s(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::S(single));
     }
 
+    /// Inserts an adjoint :math:`S` gate.
+    ///
+    /// :param Value qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn s_adj(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::SAdj(single));
     }
 
+    /// Inserts a :math:`T` gate.
+    ///
+    /// :param Value qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn t(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::T(single));
     }
 
+    /// Inserts an adjoint :math:`T` gate.
+    ///
+    /// :param qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn t_adj(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::TAdj(single));
     }
 
+    /// Inserts a Pauli :math:`X` gate.
+    ///
+    /// :param Value qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn x(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::X(single));
     }
 
+    /// Inserts a Pauli :math:`Y` gate.
+    ///
+    /// :param Value qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn y(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::Y(single));
     }
 
+    /// Inserts a Pauli :math:`Z` gate.
+    ///
+    /// :param Value qubit: The target qubit.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, qubit)")]
     fn z(&self, py: Python, qubit: Value) {
         let single = Single::new(qubit.0);
         self.push_inst(py, Instruction::Z(single));
     }
 
+    /// Inserts a branch conditioned on a measurement result.
+    ///
+    /// Instructions inserted when ``one`` is called will be inserted into the one branch.
+    /// Instructions inserted when ``zero`` is called will be inserted into the zero branch. The one
+    /// and zero callables should use this module's builder to build instructions.
+    ///
+    /// :param Value cond: The result condition to branch on.
+    /// :param Callable[[], None] one:
+    ///     A callable that inserts instructions for the branch where the result is one.
+    /// :param Callable[[], None] zero:
+    ///     A callable that inserts instructions for the branch where the result is zero.
+    /// :rtype: None
+    #[pyo3(text_signature = "(self, cond, one, zero)")]
     fn if_result(
         &self,
         py: Python,
@@ -545,6 +741,48 @@ impl BasicQisBuilder {
         let builder = self.builder.as_ref(py).borrow();
         builder.push_inst(inst);
     }
+}
+
+/// Converts the supplied QIR string to its bitcode equivalent.
+///
+/// :param str ir: The QIR string to convert
+/// :param Optional[str] module_name: The name of the QIR module, default is "" if None
+/// :param Optional[str] source_file_name: The source file name of the QIR module. Unchanged if None
+/// :return: The equivalent bitcode as bytes.
+/// :rtype: bytes
+#[pyfunction]
+#[pyo3(text_signature = "(ir, module_name=None, source_file_name=None)")]
+#[allow(clippy::needless_pass_by_value)]
+fn ir_to_bitcode<'a>(
+    py: Python<'a>,
+    ir: &str,
+    module_name: Option<String>,
+    source_file_name: Option<String>,
+) -> PyResult<&'a PyBytes> {
+    let bitcode = qirlib::generation::ir_to_bitcode(ir, &module_name, &source_file_name)
+        .map_err(PyOSError::new_err)?;
+    Ok(PyBytes::new(py, &bitcode))
+}
+
+/// Converts the supplied bitcode to its QIR string equivalent.
+///
+/// :param bytes ir: The bitcode bytes to convert
+/// :param Optional[str] module_name: The name of the QIR module, default is "" if None
+/// :param Optional[str] source_file_name: The source file name of the QIR module. Unchanged if None
+/// :return: The equivalent QIR string.
+/// :rtype: str
+#[pyfunction]
+#[pyo3(text_signature = "(bitcode, module_name=None, source_file_name=None)")]
+#[allow(clippy::needless_pass_by_value)]
+fn bitcode_to_ir<'a>(
+    py: Python<'a>,
+    bitcode: &PyBytes,
+    module_name: Option<String>,
+    source_file_name: Option<String>,
+) -> PyResult<&'a PyString> {
+    let ir = qirlib::generation::bitcode_to_ir(bitcode.as_bytes(), &module_name, &source_file_name)
+        .map_err(PyOSError::new_err)?;
+    Ok(PyUnicode::new(py, ir.as_str()))
 }
 
 fn extract_sentinel(module_name: &str, type_name: &str, ob: &PyAny) -> PyResult<()> {


### PR DESCRIPTION
- Move the docstrings from .pyi to Rust doc comments, so PyO3 attaches them to the Python `__doc__` attribute.
- Add parameter types and return types to the docstrings (this duplicates information still in the .pyi file).
- Add text_signature attributes.

This approach unfortunately has a lot of information duplication, but it seems like this is just where the state of the tooling is for creating Python native modules with good documentation. Some of the open issues in the toolchain:

- https://github.com/PyO3/pyo3/issues/310
- https://github.com/PyO3/pyo3/issues/510
- https://github.com/PyO3/pyo3/issues/1112
  - https://github.com/python/cpython/issues/47458
- https://github.com/sphinx-doc/sphinx/issues/7630

Closes #62.