### PR TITLE
Fix if_result signature in pyi file

### DIFF
--- a/pyqir-generator/pyqir/generator/_native.pyi
+++ b/pyqir-generator/pyqir/generator/_native.pyi
@@ -63,7 +63,7 @@ class BasicQisBuilder:
     def z(self, qubit: Value) -> None: ...
     def if_result(
         self,
-        result: Value,
+        cond: Value,
         one: Callable[[], None] = ...,
         zero: Callable[[], None] = ...,
     ) -> None: ...


### PR DESCRIPTION
_native.pyi spelled `if_result`'s first parameter `result`, but the implementation spelled it `cond`. That meant that using `result` would typecheck but fail at runtime, and using `cond` would work at runtime but fail to typecheck. Updated the pyi file to match the implementation.