### PR TITLE
Fix Module.bitcode() use-after-free

### DIFF
--- a/pyqir/src/module.rs
+++ b/pyqir/src/module.rs
@@ -167,14 +167,12 @@ impl Module {
     /// :type: bytes
     #[getter]
     fn bitcode<'py>(&self, py: Python<'py>) -> &'py PyBytes {
-        let bytes = unsafe {
+        unsafe {
             let buffer = MemoryBuffer::from_raw(LLVMWriteBitcodeToMemoryBuffer(self.as_ptr()));
-            slice::from_raw_parts(
-                LLVMGetBufferStart(buffer.as_ptr()).cast(),
-                LLVMGetBufferSize(buffer.as_ptr()),
-            )
-        };
-        PyBytes::new(py, bytes)
+            let start = LLVMGetBufferStart(buffer.as_ptr());
+            let len = LLVMGetBufferSize(buffer.as_ptr());
+            PyBytes::new(py, slice::from_raw_parts(start.cast(), len))
+        }
     }
 
     /// The LLVM context.


### PR DESCRIPTION
`bytes` is a slice into a memory buffer that is scoped to the block in `let bytes = unsafe { ... };`. When `PyBytes::new` copies it, the memory buffer has already been freed.