### PR TITLE
Add ccx gate

### DIFF
--- a/pyqir/pyqir/_basicqis.py
+++ b/pyqir/pyqir/_basicqis.py
@@ -26,6 +26,16 @@ class BasicQisBuilder:
         """
         qis.cx(self._builder, control, target)
 
+    def ccx(self, control1: Value, control2: Value, target: Value) -> None:
+        """
+        Inserts a double-controlled Pauli :math:`X` gate.
+
+        :param control1: The first control qubit.
+        :param control2: The second control qubit.
+        :param target: The target qubit.
+        """
+        qis.ccx(self._builder, control1, control2, target)
+
     def cz(self, control: Value, target: Value) -> None:
         """
         Inserts a controlled Pauli :math:`Z` gate.


### PR DESCRIPTION
CCX gate declared elsewhere but not in `_basicqis.py`, resulting in `AttributeError: 'builtins.BasicQisBuilder' object has no attribute 'ccx'`.