### PR TITLE
Spec compliance: change num_required_* to required_num_*

### DIFF
--- a/pyqir/README.md
+++ b/pyqir/README.md
@@ -68,7 +68,7 @@ declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
 
 declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
 
-attributes #0 = { "entry_point" "num_required_qubits"="2" "num_required_results"="2" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}

--- a/pyqir/pyqir/_entry_point.py
+++ b/pyqir/pyqir/_entry_point.py
@@ -29,8 +29,8 @@ def entry_point(
     void = pyqir.Type.void(module.context)
     function = Function(FunctionType(void, []), Linkage.EXTERNAL, name, module)
     add_string_attribute(function, "entry_point")
-    add_string_attribute(function, "num_required_qubits", str(required_num_qubits))
-    add_string_attribute(function, "num_required_results", str(required_num_results))
+    add_string_attribute(function, "required_num_qubits", str(required_num_qubits))
+    add_string_attribute(function, "required_num_results", str(required_num_results))
     add_string_attribute(function, "qir_profiles", qir_profiles)
 
     add_string_attribute(

--- a/pyqir/tests/resources/test_empty_false_block.ll
+++ b/pyqir/tests/resources/test_empty_false_block.ll
@@ -24,7 +24,7 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}
 

--- a/pyqir/tests/resources/test_empty_true_block.ll
+++ b/pyqir/tests/resources/test_empty_true_block.ll
@@ -24,7 +24,7 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}
 

--- a/pyqir/tests/resources/test_if_empty_blocks.ll
+++ b/pyqir/tests/resources/test_if_empty_blocks.ll
@@ -20,7 +20,7 @@ continue:                                         ; preds = %else, %then
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="1" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}
 

--- a/pyqir/tests/resources/test_nested_blocks.ll
+++ b/pyqir/tests/resources/test_nested_blocks.ll
@@ -53,7 +53,7 @@ declare void @__quantum__qis__z__body(%Qubit*)
 
 declare void @__quantum__qis__t__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="3" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="3" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}
 

--- a/qirlib/resources/tests/module/many_required_qubits_results.ll
+++ b/qirlib/resources/tests/module/many_required_qubits_results.ll
@@ -5,4 +5,4 @@ define void @main() #0 {
   ret void
 }
 
-attributes #0 = { "entry_point" "num_required_qubits"="5" "num_required_results"="7" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="5" "required_num_results"="7" }

--- a/qirlib/resources/tests/module/one_required_qubit.ll
+++ b/qirlib/resources/tests/module/one_required_qubit.ll
@@ -5,4 +5,4 @@ define void @main() #0 {
   ret void
 }
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/module/one_required_result.ll
+++ b/qirlib/resources/tests/module/one_required_result.ll
@@ -5,4 +5,4 @@ define void @main() #0 {
   ret void
 }
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="1" }

--- a/qirlib/resources/tests/module/zero_required_qubits_results.ll
+++ b/qirlib/resources/tests/module/zero_required_qubits_results.ll
@@ -5,4 +5,4 @@ define void @main() #0 {
   ret void
 }
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/barrier.ll
+++ b/qirlib/resources/tests/qis/barrier.ll
@@ -8,4 +8,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__barrier__body()
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/ccx.ll
+++ b/qirlib/resources/tests/qis/ccx.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="3" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/cx.ll
+++ b/qirlib/resources/tests/qis/cx.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="2" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/cz.ll
+++ b/qirlib/resources/tests/qis/cz.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="2" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/empty_if.ll
+++ b/qirlib/resources/tests/qis/empty_if.ll
@@ -23,5 +23,5 @@ declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/h.ll
+++ b/qirlib/resources/tests/qis/h.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__h__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/if_else.ll
+++ b/qirlib/resources/tests/qis/if_else.ll
@@ -26,5 +26,5 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_else_continue.ll
+++ b/qirlib/resources/tests/qis/if_else_continue.ll
@@ -29,5 +29,5 @@ declare void @__quantum__qis__x__body(%Qubit*)
 
 declare void @__quantum__qis__h__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_else_else.ll
+++ b/qirlib/resources/tests/qis/if_else_else.ll
@@ -37,5 +37,5 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="2" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_else_then.ll
+++ b/qirlib/resources/tests/qis/if_else_then.ll
@@ -37,5 +37,5 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="2" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_then.ll
+++ b/qirlib/resources/tests/qis/if_then.ll
@@ -26,5 +26,5 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_then_continue.ll
+++ b/qirlib/resources/tests/qis/if_then_continue.ll
@@ -29,5 +29,5 @@ declare void @__quantum__qis__x__body(%Qubit*)
 
 declare void @__quantum__qis__h__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_then_else.ll
+++ b/qirlib/resources/tests/qis/if_then_else.ll
@@ -37,5 +37,5 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="2" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_then_else_continue.ll
+++ b/qirlib/resources/tests/qis/if_then_else_continue.ll
@@ -32,5 +32,5 @@ declare void @__quantum__qis__y__body(%Qubit*)
 
 declare void @__quantum__qis__h__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_then_then.ll
+++ b/qirlib/resources/tests/qis/if_then_then.ll
@@ -37,5 +37,5 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="2" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/if_unmeasured_result.ll
+++ b/qirlib/resources/tests/qis/if_unmeasured_result.ll
@@ -26,4 +26,4 @@ declare void @__quantum__qis__x__body(%Qubit*)
 
 declare void @__quantum__qis__h__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }

--- a/qirlib/resources/tests/qis/mz.ll
+++ b/qirlib/resources/tests/qis/mz.ll
@@ -11,5 +11,5 @@ define void @main() #0 {
 
 declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }

--- a/qirlib/resources/tests/qis/read_result.ll
+++ b/qirlib/resources/tests/qis/read_result.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }

--- a/qirlib/resources/tests/qis/reset.ll
+++ b/qirlib/resources/tests/qis/reset.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__reset__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/rx.ll
+++ b/qirlib/resources/tests/qis/rx.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__rx__body(double, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/ry.ll
+++ b/qirlib/resources/tests/qis/ry.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__ry__body(double, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/rz.ll
+++ b/qirlib/resources/tests/qis/rz.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__rz__body(double, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/s.ll
+++ b/qirlib/resources/tests/qis/s.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__s__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/s_adj.ll
+++ b/qirlib/resources/tests/qis/s_adj.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__s__adj(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/swap.ll
+++ b/qirlib/resources/tests/qis/swap.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="2" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/t.ll
+++ b/qirlib/resources/tests/qis/t.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__t__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/t_adj.ll
+++ b/qirlib/resources/tests/qis/t_adj.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__t__adj(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/x.ll
+++ b/qirlib/resources/tests/qis/x.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/y.ll
+++ b/qirlib/resources/tests/qis/y.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__y__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/qis/z.ll
+++ b/qirlib/resources/tests/qis/z.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__qis__z__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="1" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="0" }

--- a/qirlib/resources/tests/rt/array_record_output.ll
+++ b/qirlib/resources/tests/rt/array_record_output.ll
@@ -8,4 +8,4 @@ define void @main() #0 {
 
 declare void @__quantum__rt__array_record_output(i64, i8*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="0" }

--- a/qirlib/resources/tests/rt/initialize.ll
+++ b/qirlib/resources/tests/rt/initialize.ll
@@ -8,4 +8,4 @@ define void @main() #0 {
 
 declare void @__quantum__rt__initialize(i8*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="0" }

--- a/qirlib/resources/tests/rt/result_record_output.ll
+++ b/qirlib/resources/tests/rt/result_record_output.ll
@@ -10,4 +10,4 @@ define void @main() #0 {
 
 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="1" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="1" }

--- a/qirlib/resources/tests/rt/tuple_record_output.ll
+++ b/qirlib/resources/tests/rt/tuple_record_output.ll
@@ -8,4 +8,4 @@ define void @main() #0 {
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="0" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="0" "required_num_results"="0" }

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -54,12 +54,12 @@ pub unsafe fn entry_point(
     add_string_attribute(function, b"entry_point", b"");
     add_string_attribute(
         function,
-        b"num_required_qubits",
+        b"required_num_qubits",
         required_num_qubits.to_string().as_bytes(),
     );
     add_string_attribute(
         function,
-        b"num_required_results",
+        b"required_num_results",
         required_num_results.to_string().as_bytes(),
     );
 
@@ -93,7 +93,10 @@ pub unsafe fn is_interop_friendly(function: LLVMValueRef) -> bool {
 pub unsafe fn required_num_qubits(function: LLVMValueRef) -> Option<u64> {
     if LLVMGetValueKind(function) == LLVMValueKind::LLVMFunctionValueKind {
         let required_qubits =
-            get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_qubits")
+            get_string_attribute(function, LLVMAttributeFunctionIndex, b"required_num_qubits")
+                .or_else(|| {
+                    get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_qubits")
+                })
                 .or_else(|| {
                     get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredQubits")
                 })?;
@@ -112,8 +115,11 @@ pub unsafe fn required_num_results(function: LLVMValueRef) -> Option<u64> {
         let required_results = get_string_attribute(
             function,
             LLVMAttributeFunctionIndex,
-            b"num_required_results",
+            b"required_num_results",
         )
+        .or_else(|| {
+            get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_results")
+        })
         .or_else(|| {
             get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredResults")
         })?;

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -95,7 +95,11 @@ pub unsafe fn required_num_qubits(function: LLVMValueRef) -> Option<u64> {
         let required_qubits =
             get_string_attribute(function, LLVMAttributeFunctionIndex, b"required_num_qubits")
                 .or_else(|| {
-                    get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_qubits")
+                    get_string_attribute(
+                        function,
+                        LLVMAttributeFunctionIndex,
+                        b"num_required_qubits",
+                    )
                 })
                 .or_else(|| {
                     get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredQubits")
@@ -118,7 +122,11 @@ pub unsafe fn required_num_results(function: LLVMValueRef) -> Option<u64> {
             b"required_num_results",
         )
         .or_else(|| {
-            get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_results")
+            get_string_attribute(
+                function,
+                LLVMAttributeFunctionIndex,
+                b"num_required_results",
+            )
         })
         .or_else(|| {
             get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredResults")


### PR DESCRIPTION
As described in Issue #250, the Base Profile spec specifies that `required_num_qubits` and `required_num_results` must be used in the entry point function. This change updates the pyqir project to use those attributes in all places. I _think_ it also maintains ability to parse old `num_required_*` attributes in order to maintain as much backwards compatibility as possible, but please let me know if I've missed anything there.