### PR TITLE
Update attr fallback order to support legacy processing.

### DIFF
--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -102,7 +102,11 @@ pub unsafe fn required_num_qubits(function: LLVMValueRef) -> Option<u64> {
                     )
                 })
                 .or_else(|| {
-                    get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_qubits")
+                    get_string_attribute(
+                        function,
+                        LLVMAttributeFunctionIndex,
+                        b"num_required_qubits",
+                    )
                 })?;
 
         let mut len = 0;
@@ -116,21 +120,22 @@ pub unsafe fn required_num_qubits(function: LLVMValueRef) -> Option<u64> {
 
 pub unsafe fn required_num_results(function: LLVMValueRef) -> Option<u64> {
     if LLVMGetValueKind(function) == LLVMValueKind::LLVMFunctionValueKind {
-        let required_results = get_string_attribute(
-            function,
-            LLVMAttributeFunctionIndex,
-            b"requiredResults",
-        )
-        .or_else(|| {
-            get_string_attribute(
-                function,
-                LLVMAttributeFunctionIndex,
-                b"required_num_results",
-            )
-        })
-        .or_else(|| {
-            get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_results")
-        })?;
+        let required_results =
+            get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredResults")
+                .or_else(|| {
+                    get_string_attribute(
+                        function,
+                        LLVMAttributeFunctionIndex,
+                        b"required_num_results",
+                    )
+                })
+                .or_else(|| {
+                    get_string_attribute(
+                        function,
+                        LLVMAttributeFunctionIndex,
+                        b"num_required_results",
+                    )
+                })?;
         let mut len = 0;
         let value = LLVMGetStringAttributeValue(required_results.as_ptr(), &mut len);
         let value = slice::from_raw_parts(value.cast(), len.try_into().unwrap());

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -93,16 +93,16 @@ pub unsafe fn is_interop_friendly(function: LLVMValueRef) -> bool {
 pub unsafe fn required_num_qubits(function: LLVMValueRef) -> Option<u64> {
     if LLVMGetValueKind(function) == LLVMValueKind::LLVMFunctionValueKind {
         let required_qubits =
-            get_string_attribute(function, LLVMAttributeFunctionIndex, b"required_num_qubits")
+            get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredQubits")
                 .or_else(|| {
                     get_string_attribute(
                         function,
                         LLVMAttributeFunctionIndex,
-                        b"num_required_qubits",
+                        b"required_num_qubits",
                     )
                 })
                 .or_else(|| {
-                    get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredQubits")
+                    get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_qubits")
                 })?;
 
         let mut len = 0;
@@ -119,17 +119,17 @@ pub unsafe fn required_num_results(function: LLVMValueRef) -> Option<u64> {
         let required_results = get_string_attribute(
             function,
             LLVMAttributeFunctionIndex,
-            b"required_num_results",
+            b"requiredResults",
         )
         .or_else(|| {
             get_string_attribute(
                 function,
                 LLVMAttributeFunctionIndex,
-                b"num_required_results",
+                b"required_num_results",
             )
         })
         .or_else(|| {
-            get_string_attribute(function, LLVMAttributeFunctionIndex, b"requiredResults")
+            get_string_attribute(function, LLVMAttributeFunctionIndex, b"num_required_results")
         })?;
         let mut len = 0;
         let value = LLVMGetStringAttributeValue(required_results.as_ptr(), &mut len);


### PR DESCRIPTION
Legacy processing updated required(Qubits|Results) but left the originals unchanged. This sets the order to look for the legacy values (which are the most correct until processing is updated) followed by the correct attr, and then the bugged attr values.