### PR TITLE
Get building on LLVM 18.1 (...But not working)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,20 @@ dependencies = [
  "lazy_static",
  "libc",
  "regex",
+ "semver 1.0.21",
+]
+
+[[package]]
+name = "llvm-sys"
+version = "181.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e770c3c1ba28b4be3b4f4a7bc621fdb3f10b325f042e7d51dd9298db231df6f"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
  "semver 1.0.21",
 ]
 
@@ -311,6 +331,7 @@ dependencies = [
  "llvm-sys 120.3.2",
  "llvm-sys 130.1.2",
  "llvm-sys 140.1.3",
+ "llvm-sys 181.0.0",
  "pyo3",
  "qirlib",
 ]
@@ -328,6 +349,7 @@ dependencies = [
  "llvm-sys 120.3.2",
  "llvm-sys 130.1.2",
  "llvm-sys 140.1.3",
+ "llvm-sys 181.0.0",
  "log",
  "mut_static",
  "normalize-line-endings",
@@ -379,6 +401,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
 
 [[package]]
 name = "regex-syntax"

--- a/pyqir/Cargo.toml
+++ b/pyqir/Cargo.toml
@@ -15,6 +15,7 @@ llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
 llvm-sys-120 = { package = "llvm-sys", version = "120.3", optional = true }
 llvm-sys-130 = { package = "llvm-sys", version = "130.1", optional = true }
 llvm-sys-140 = { package = "llvm-sys", version = "140.1", optional = true }
+llvm-sys-181 = { package = "llvm-sys", version = "181", optional = true }
 pyo3 = { version = "0.19", features = ["abi3-py38", "extension-module"] }
 qirlib = { path = "../qirlib" }
 
@@ -23,6 +24,7 @@ llvm11-0 = ["llvm-sys-110", "qirlib/llvm11-0"]
 llvm12-0 = ["llvm-sys-120", "qirlib/llvm12-0"]
 llvm13-0 = ["llvm-sys-130", "qirlib/llvm13-0"]
 llvm14-0 = ["llvm-sys-140", "qirlib/llvm14-0"]
+llvm18-1 = ["llvm-sys-181", "qirlib/llvm18-1"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/pyqir/src/builder.rs
+++ b/pyqir/src/builder.rs
@@ -234,9 +234,9 @@ impl Builder {
                 .map(|(arg, ty)| arg.to_value(ty).map_err(Into::into))
                 .collect::<PyResult<Vec<_>>>()?;
 
-            #[allow(deprecated)]
-            let value = LLVMBuildCall(
+            let value = LLVMBuildCall2(
                 self.as_ptr(),
+                fn_type,
                 callee.as_ptr(),
                 args.as_mut_ptr(),
                 args.len().try_into().unwrap(),

--- a/pyqir/src/lib.rs
+++ b/pyqir/src/lib.rs
@@ -13,6 +13,8 @@ extern crate llvm_sys_120 as llvm_sys;
 extern crate llvm_sys_130 as llvm_sys;
 #[cfg(feature = "llvm14-0")]
 extern crate llvm_sys_140 as llvm_sys;
+#[cfg(feature = "llvm18-1")]
+extern crate llvm_sys_181 as llvm_sys;
 
 mod builder;
 mod core;

--- a/pyqir/src/types.rs
+++ b/pyqir/src/types.rs
@@ -268,8 +268,8 @@ impl ArrayType {
     ///
     /// :type: int
     #[getter]
-    fn count(slf: PyRef<Self>) -> u32 {
-        unsafe { LLVMGetArrayLength(slf.into_super().as_ptr()) }
+    fn count(slf: PyRef<Self>) -> u64 {
+        unsafe { LLVMGetArrayLength2(slf.into_super().as_ptr()) }
     }
 }
 

--- a/qirlib/Cargo.toml
+++ b/qirlib/Cargo.toml
@@ -18,6 +18,7 @@ llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
 llvm-sys-120 = { package = "llvm-sys", version = "120.3", optional = true }
 llvm-sys-130 = { package = "llvm-sys", version = "130.1", optional = true }
 llvm-sys-140 = { package = "llvm-sys", version = "140.1", optional = true }
+llvm-sys-181 = { package = "llvm-sys", version = "181", optional = true }
 log = "0.4"
 mut_static = "5.0"
 
@@ -37,6 +38,7 @@ llvm11-0 = ["llvm-sys-110"]
 llvm12-0 = ["llvm-sys-120"]
 llvm13-0 = ["llvm-sys-130"]
 llvm14-0 = ["llvm-sys-140"]
+llvm18-1 = ["llvm-sys-181"]
 
 # default to use llvm-sys for llvm linking
 default = ["external-llvm-linking"]

--- a/qirlib/build.rs
+++ b/qirlib/build.rs
@@ -23,29 +23,34 @@ extern crate lazy_static;
     not(any(feature = "llvm12-0")),
     not(any(feature = "llvm13-0")),
     not(any(feature = "llvm14-0")),
+    not(any(feature = "llvm18-1")),
 ))]
-compile_error!("One of the features `qirlib/llvm11-0`, `qirlib/llvm12-0`, `qirlib/llvm13-0`, and `qirlib/llvm14-0` must be used exclusive.");
+compile_error!("One of the features `qirlib/llvm11-0`, `qirlib/llvm12-0`, `qirlib/llvm13-0`, `qirlib/llvm14-0`, and `qirlib/llvm18-1` must be used exclusive.");
 
 // Make sure only one llvm option is used.
 #[cfg(any(
     all(
         feature = "llvm11-0",
-        any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0")
+        any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm18-1")
     ),
     all(
         feature = "llvm12-0",
-        any(feature = "llvm11-0", feature = "llvm13-0", feature = "llvm14-0")
+        any(feature = "llvm11-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm18-1")
     ),
     all(
         feature = "llvm13-0",
-        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm14-0")
+        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm14-0", feature = "llvm18-1")
     ),
     all(
         feature = "llvm14-0",
-        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm13-0")
+        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm13-0", feature = "llvm18-1")
+    ),
+    all(
+        feature = "llvm18-1",
+        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0")
     ),
 ))]
-compile_error!("Features `qirlib/llvm11-0`, `qirlib/llvm12-0`, `qirlib/llvm13-0`, and `qirlib/llvm14-0` must be used exclusive.");
+compile_error!("Features `qirlib/llvm11-0`, `qirlib/llvm12-0`, `qirlib/llvm13-0`, `qirlib/llvm14-0`, and `qirlib/llvm18-1` must be used exclusive.");
 
 // Make sure one of the linking features is used
 #[cfg(all(
@@ -382,6 +387,8 @@ fn locate_llvm_config() -> Option<PathBuf> {
         "13"
     } else if cfg!(feature = "llvm14-0") {
         "14"
+    } else if cfg!(feature = "llvm18-1") {
+        "18"
     } else {
         "unknown"
     };

--- a/qirlib/build.rs
+++ b/qirlib/build.rs
@@ -31,23 +31,48 @@ compile_error!("One of the features `qirlib/llvm11-0`, `qirlib/llvm12-0`, `qirli
 #[cfg(any(
     all(
         feature = "llvm11-0",
-        any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm18-1")
+        any(
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0",
+            feature = "llvm18-1"
+        )
     ),
     all(
         feature = "llvm12-0",
-        any(feature = "llvm11-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm18-1")
+        any(
+            feature = "llvm11-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0",
+            feature = "llvm18-1"
+        )
     ),
     all(
         feature = "llvm13-0",
-        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm14-0", feature = "llvm18-1")
+        any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm14-0",
+            feature = "llvm18-1"
+        )
     ),
     all(
         feature = "llvm14-0",
-        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm13-0", feature = "llvm18-1")
+        any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm18-1"
+        )
     ),
     all(
         feature = "llvm18-1",
-        any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0")
+        any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        )
     ),
 ))]
 compile_error!("Features `qirlib/llvm11-0`, `qirlib/llvm12-0`, `qirlib/llvm13-0`, `qirlib/llvm14-0`, and `qirlib/llvm18-1` must be used exclusive.");

--- a/qirlib/src/lib.rs
+++ b/qirlib/src/lib.rs
@@ -16,6 +16,8 @@ extern crate llvm_sys_120 as llvm_sys;
 extern crate llvm_sys_130 as llvm_sys;
 #[cfg(feature = "llvm14-0")]
 extern crate llvm_sys_140 as llvm_sys;
+#[cfg(feature = "llvm18-1")]
+extern crate llvm_sys_181 as llvm_sys;
 
 #[cfg(not(feature = "no-llvm-linking"))]
 pub mod builder;

--- a/qirlib/src/qis.rs
+++ b/qirlib/src/qis.rs
@@ -17,12 +17,7 @@ use llvm_sys::{core::*, prelude::*};
 
 pub unsafe fn build_barrier(builder: LLVMBuilderRef) {
     let (func_ty, func_val) = no_param(builder_module(builder), "barrier", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [],
-    );
+    build_call(builder, func_ty, func_val, &mut []);
 }
 
 pub unsafe fn build_ccx(
@@ -32,172 +27,87 @@ pub unsafe fn build_ccx(
     qubit: LLVMValueRef,
 ) {
     let (func_ty, func_val) = doubly_controlled_gate(builder_module(builder), "ccx");
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [control1, control2, qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [control1, control2, qubit]);
 }
 
 pub unsafe fn build_cx(builder: LLVMBuilderRef, control: LLVMValueRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = controlled_gate(builder_module(builder), "cnot");
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [control, qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [control, qubit]);
 }
 
 pub unsafe fn build_cz(builder: LLVMBuilderRef, control: LLVMValueRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = controlled_gate(builder_module(builder), "cz");
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [control, qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [control, qubit]);
 }
 
 pub unsafe fn build_h(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "h", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_s(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "s", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_s_adj(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "s", Functor::Adjoint);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_swap(builder: LLVMBuilderRef, qubit1: LLVMValueRef, qubit2: LLVMValueRef) {
     let (func_ty, func_val) = two_qubit_gate(builder_module(builder), "swap", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit1, qubit2],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit1, qubit2]);
 }
 
 pub unsafe fn build_t(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "t", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_t_adj(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "t", Functor::Adjoint);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_x(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "x", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_y(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "y", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_z(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "z", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_rx(builder: LLVMBuilderRef, theta: LLVMValueRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = rotation_gate(builder_module(builder), "rx");
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [theta, qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [theta, qubit]);
 }
 
 pub unsafe fn build_ry(builder: LLVMBuilderRef, theta: LLVMValueRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = rotation_gate(builder_module(builder), "ry");
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [theta, qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [theta, qubit]);
 }
 
 pub unsafe fn build_rz(builder: LLVMBuilderRef, theta: LLVMValueRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = rotation_gate(builder_module(builder), "rz");
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [theta, qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [theta, qubit]);
 }
 
 pub unsafe fn build_reset(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
     let (func_ty, func_val) = simple_gate(builder_module(builder), "reset", Functor::Body);
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit],
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit]);
 }
 
 pub unsafe fn build_mz(builder: LLVMBuilderRef, qubit: LLVMValueRef, result: LLVMValueRef) {
     let (func_ty, func_val) = mz(builder_module(builder));
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [qubit, result]
-    );
+    build_call(builder, func_ty, func_val, &mut [qubit, result]);
 }
 
 pub unsafe fn build_if_result(
@@ -222,12 +132,7 @@ pub unsafe fn try_build_if_result<E>(
 
 unsafe fn build_read_result(builder: LLVMBuilderRef, result: LLVMValueRef) -> LLVMValueRef {
     let (func_ty, func_val) = read_result(builder_module(builder));
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [result]
-    )
+    build_call(builder, func_ty, func_val, &mut [result])
 }
 
 unsafe fn mz(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {

--- a/qirlib/src/qis.rs
+++ b/qirlib/src/qis.rs
@@ -16,9 +16,11 @@ use llvm_sys::LLVMAttributeFunctionIndex;
 use llvm_sys::{core::*, prelude::*};
 
 pub unsafe fn build_barrier(builder: LLVMBuilderRef) {
+    let (func_ty, func_val) = no_param(builder_module(builder), "barrier", Functor::Body);
     build_call(
         builder,
-        no_param(builder_module(builder), "barrier", Functor::Body),
+        func_ty,
+        func_val,
         &mut [],
     );
 }
@@ -29,135 +31,173 @@ pub unsafe fn build_ccx(
     control2: LLVMValueRef,
     qubit: LLVMValueRef,
 ) {
+    let (func_ty, func_val) = doubly_controlled_gate(builder_module(builder), "ccx");
     build_call(
         builder,
-        doubly_controlled_gate(builder_module(builder), "ccx"),
+        func_ty,
+        func_val,
         &mut [control1, control2, qubit],
     );
 }
 
 pub unsafe fn build_cx(builder: LLVMBuilderRef, control: LLVMValueRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = controlled_gate(builder_module(builder), "cnot");
     build_call(
         builder,
-        controlled_gate(builder_module(builder), "cnot"),
+        func_ty,
+        func_val,
         &mut [control, qubit],
     );
 }
 
 pub unsafe fn build_cz(builder: LLVMBuilderRef, control: LLVMValueRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = controlled_gate(builder_module(builder), "cz");
     build_call(
         builder,
-        controlled_gate(builder_module(builder), "cz"),
+        func_ty,
+        func_val,
         &mut [control, qubit],
     );
 }
 
 pub unsafe fn build_h(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "h", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "h", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_s(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "s", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "s", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_s_adj(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "s", Functor::Adjoint);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "s", Functor::Adjoint),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_swap(builder: LLVMBuilderRef, qubit1: LLVMValueRef, qubit2: LLVMValueRef) {
+    let (func_ty, func_val) = two_qubit_gate(builder_module(builder), "swap", Functor::Body);
     build_call(
         builder,
-        two_qubit_gate(builder_module(builder), "swap", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit1, qubit2],
     );
 }
 
 pub unsafe fn build_t(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "t", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "t", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_t_adj(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "t", Functor::Adjoint);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "t", Functor::Adjoint),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_x(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "x", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "x", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_y(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "y", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "y", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_z(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "z", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "z", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_rx(builder: LLVMBuilderRef, theta: LLVMValueRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = rotation_gate(builder_module(builder), "rx");
     build_call(
         builder,
-        rotation_gate(builder_module(builder), "rx"),
+        func_ty,
+        func_val,
         &mut [theta, qubit],
     );
 }
 
 pub unsafe fn build_ry(builder: LLVMBuilderRef, theta: LLVMValueRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = rotation_gate(builder_module(builder), "ry");
     build_call(
         builder,
-        rotation_gate(builder_module(builder), "ry"),
+        func_ty,
+        func_val,
         &mut [theta, qubit],
     );
 }
 
 pub unsafe fn build_rz(builder: LLVMBuilderRef, theta: LLVMValueRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = rotation_gate(builder_module(builder), "rz");
     build_call(
         builder,
-        rotation_gate(builder_module(builder), "rz"),
+        func_ty,
+        func_val,
         &mut [theta, qubit],
     );
 }
 
 pub unsafe fn build_reset(builder: LLVMBuilderRef, qubit: LLVMValueRef) {
+    let (func_ty, func_val) = simple_gate(builder_module(builder), "reset", Functor::Body);
     build_call(
         builder,
-        simple_gate(builder_module(builder), "reset", Functor::Body),
+        func_ty,
+        func_val,
         &mut [qubit],
     );
 }
 
 pub unsafe fn build_mz(builder: LLVMBuilderRef, qubit: LLVMValueRef, result: LLVMValueRef) {
-    build_call(builder, mz(builder_module(builder)), &mut [qubit, result]);
+    let (func_ty, func_val) = mz(builder_module(builder));
+    build_call(
+        builder,
+        func_ty,
+        func_val,
+        &mut [qubit, result]
+    );
 }
 
 pub unsafe fn build_if_result(
@@ -181,10 +221,16 @@ pub unsafe fn try_build_if_result<E>(
 }
 
 unsafe fn build_read_result(builder: LLVMBuilderRef, result: LLVMValueRef) -> LLVMValueRef {
-    build_call(builder, read_result(builder_module(builder)), &mut [result])
+    let (func_ty, func_val) = read_result(builder_module(builder));
+    build_call(
+        builder,
+        func_ty,
+        func_val,
+        &mut [result]
+    )
 }
 
-unsafe fn mz(module: LLVMModuleRef) -> LLVMValueRef {
+unsafe fn mz(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let result_type = types::result(context);
     let ty = function_type(
@@ -200,7 +246,7 @@ unsafe fn mz(module: LLVMModuleRef) -> LLVMValueRef {
     LLVMAddAttributeAtIndex(function, result_param_index, attr);
 
     add_irreversible_attr(context, function);
-    function
+    (ty, function)
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -216,13 +262,13 @@ unsafe fn add_irreversible_attr(context: LLVMContextRef, function: LLVMValueRef)
     LLVMAddAttributeAtIndex(function, LLVMAttributeFunctionIndex, irreversable_attr);
 }
 
-unsafe fn read_result(module: LLVMModuleRef) -> LLVMValueRef {
+unsafe fn read_result(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let ty = function_type(
         LLVMInt1TypeInContext(context),
         &mut [types::result(context)],
     );
-    declare_qis(module, "read_result", Functor::Body, ty)
+    (ty, declare_qis(module, "read_result", Functor::Body, ty))
 }
 
 #[cfg(test)]

--- a/qirlib/src/rt.rs
+++ b/qirlib/src/rt.rs
@@ -20,22 +20,12 @@ pub unsafe fn build_array_record_output(
     label: LLVMValueRef,
 ) {
     let (func_ty, func_val) = array_record_output(builder_module(builder));
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [num_elements, label],
-    );
+    build_call(builder, func_ty, func_val, &mut [num_elements, label]);
 }
 
 pub unsafe fn build_initialize(builder: LLVMBuilderRef, data: LLVMValueRef) {
     let (func_ty, func_val) = initialize(builder_module(builder));
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [data]
-    );
+    build_call(builder, func_ty, func_val, &mut [data]);
 }
 
 pub unsafe fn build_result_record_output(
@@ -44,12 +34,7 @@ pub unsafe fn build_result_record_output(
     label: LLVMValueRef,
 ) {
     let (func_ty, func_val) = result_record_output(builder_module(builder));
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [result, label],
-    );
+    build_call(builder, func_ty, func_val, &mut [result, label]);
 }
 
 pub unsafe fn build_tuple_record_output(
@@ -58,12 +43,7 @@ pub unsafe fn build_tuple_record_output(
     label: LLVMValueRef,
 ) {
     let (func_ty, func_val) = tuple_record_output(builder_module(builder));
-    build_call(
-        builder,
-        func_ty,
-        func_val,
-        &mut [num_elements, label],
-    );
+    build_call(builder, func_ty, func_val, &mut [num_elements, label]);
 }
 
 unsafe fn array_record_output(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {

--- a/qirlib/src/rt.rs
+++ b/qirlib/src/rt.rs
@@ -19,15 +19,23 @@ pub unsafe fn build_array_record_output(
     num_elements: LLVMValueRef,
     label: LLVMValueRef,
 ) {
+    let (func_ty, func_val) = array_record_output(builder_module(builder));
     build_call(
         builder,
-        array_record_output(builder_module(builder)),
+        func_ty,
+        func_val,
         &mut [num_elements, label],
     );
 }
 
 pub unsafe fn build_initialize(builder: LLVMBuilderRef, data: LLVMValueRef) {
-    build_call(builder, initialize(builder_module(builder)), &mut [data]);
+    let (func_ty, func_val) = initialize(builder_module(builder));
+    build_call(
+        builder,
+        func_ty,
+        func_val,
+        &mut [data]
+    );
 }
 
 pub unsafe fn build_result_record_output(
@@ -35,9 +43,11 @@ pub unsafe fn build_result_record_output(
     result: LLVMValueRef,
     label: LLVMValueRef,
 ) {
+    let (func_ty, func_val) = result_record_output(builder_module(builder));
     build_call(
         builder,
-        result_record_output(builder_module(builder)),
+        func_ty,
+        func_val,
         &mut [result, label],
     );
 }
@@ -47,37 +57,39 @@ pub unsafe fn build_tuple_record_output(
     num_elements: LLVMValueRef,
     label: LLVMValueRef,
 ) {
+    let (func_ty, func_val) = tuple_record_output(builder_module(builder));
     build_call(
         builder,
-        tuple_record_output(builder_module(builder)),
+        func_ty,
+        func_val,
         &mut [num_elements, label],
     );
 }
 
-unsafe fn array_record_output(module: LLVMModuleRef) -> LLVMValueRef {
+unsafe fn array_record_output(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let param_type = LLVMInt64TypeInContext(context);
     let name = "array_record_output";
     record_output(module, name, param_type)
 }
 
-unsafe fn initialize(module: LLVMModuleRef) -> LLVMValueRef {
+unsafe fn initialize(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let i8type = LLVMInt8TypeInContext(context);
     let i8p = LLVMPointerType(i8type, 0);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [i8p]);
     let name = "__quantum__rt__initialize";
-    declare_external_function(module, name, ty)
+    (ty, declare_external_function(module, name, ty))
 }
 
-unsafe fn result_record_output(module: LLVMModuleRef) -> LLVMValueRef {
+unsafe fn result_record_output(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let param_type = types::result(context);
     let name = "result_record_output";
     record_output(module, name, param_type)
 }
 
-unsafe fn tuple_record_output(module: LLVMModuleRef) -> LLVMValueRef {
+unsafe fn tuple_record_output(module: LLVMModuleRef) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let param_type = LLVMInt64TypeInContext(context);
     let name = "tuple_record_output";
@@ -88,13 +100,13 @@ unsafe fn record_output(
     module: LLVMModuleRef,
     name: &str,
     param_type: LLVMTypeRef,
-) -> LLVMValueRef {
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let i8type = LLVMInt8TypeInContext(context);
     let i8p = LLVMPointerType(i8type, 0);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [param_type, i8p]);
     let name = format!("__quantum__rt__{name}");
-    declare_external_function(module, &name, ty)
+    (ty, declare_external_function(module, &name, ty))
 }
 
 #[cfg(test)]

--- a/qirlib/src/utils.rs
+++ b/qirlib/src/utils.rs
@@ -15,12 +15,13 @@ pub(crate) enum Functor {
 
 pub(crate) unsafe fn build_call(
     builder: LLVMBuilderRef,
+    function_type: LLVMTypeRef,
     function: LLVMValueRef,
     args: &mut [LLVMValueRef],
 ) -> LLVMValueRef {
-    #[allow(deprecated)]
-    LLVMBuildCall(
+    LLVMBuildCall2(
         builder,
+        function_type,
         function,
         args.as_mut_ptr(),
         args.len().try_into().unwrap(),
@@ -36,54 +37,54 @@ pub(crate) unsafe fn builder_module(builder: LLVMBuilderRef) -> LLVMModuleRef {
         .as_ptr()
 }
 
-pub(crate) unsafe fn no_param(module: LLVMModuleRef, name: &str, functor: Functor) -> LLVMValueRef {
+pub(crate) unsafe fn no_param(module: LLVMModuleRef, name: &str, functor: Functor) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut []);
-    declare_qis(module, name, functor, ty)
+    (ty, declare_qis(module, name, functor, ty))
 }
 
 pub(crate) unsafe fn simple_gate(
     module: LLVMModuleRef,
     name: &str,
     functor: Functor,
-) -> LLVMValueRef {
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [types::qubit(context)]);
-    declare_qis(module, name, functor, ty)
+    (ty, declare_qis(module, name, functor, ty))
 }
 
 pub(crate) unsafe fn two_qubit_gate(
     module: LLVMModuleRef,
     name: &str,
     functor: Functor,
-) -> LLVMValueRef {
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let qubit = types::qubit(context);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [qubit, qubit]);
-    declare_qis(module, name, functor, ty)
+    (ty, declare_qis(module, name, functor, ty))
 }
 
-pub(crate) unsafe fn controlled_gate(module: LLVMModuleRef, name: &str) -> LLVMValueRef {
+pub(crate) unsafe fn controlled_gate(module: LLVMModuleRef, name: &str) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let qubit = types::qubit(context);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [qubit, qubit]);
-    declare_qis(module, name, Functor::Body, ty)
+    (ty, declare_qis(module, name, Functor::Body, ty))
 }
 
-pub(crate) unsafe fn doubly_controlled_gate(module: LLVMModuleRef, name: &str) -> LLVMValueRef {
+pub(crate) unsafe fn doubly_controlled_gate(module: LLVMModuleRef, name: &str) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let qubit = types::qubit(context);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [qubit, qubit, qubit]);
-    declare_qis(module, name, Functor::Body, ty)
+    (ty, declare_qis(module, name, Functor::Body, ty))
 }
 
-pub(crate) unsafe fn rotation_gate(module: LLVMModuleRef, name: &str) -> LLVMValueRef {
+pub(crate) unsafe fn rotation_gate(module: LLVMModuleRef, name: &str) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let ty = function_type(
         LLVMVoidTypeInContext(context),
         &mut [LLVMDoubleTypeInContext(context), types::qubit(context)],
     );
-    declare_qis(module, name, Functor::Body, ty)
+    (ty, declare_qis(module, name, Functor::Body, ty))
 }
 
 pub(crate) unsafe fn function_type(ret: LLVMTypeRef, params: &mut [LLVMTypeRef]) -> LLVMTypeRef {

--- a/qirlib/src/utils.rs
+++ b/qirlib/src/utils.rs
@@ -37,7 +37,11 @@ pub(crate) unsafe fn builder_module(builder: LLVMBuilderRef) -> LLVMModuleRef {
         .as_ptr()
 }
 
-pub(crate) unsafe fn no_param(module: LLVMModuleRef, name: &str, functor: Functor) -> (LLVMTypeRef, LLVMValueRef) {
+pub(crate) unsafe fn no_param(
+    module: LLVMModuleRef,
+    name: &str,
+    functor: Functor,
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut []);
     (ty, declare_qis(module, name, functor, ty))
@@ -64,21 +68,30 @@ pub(crate) unsafe fn two_qubit_gate(
     (ty, declare_qis(module, name, functor, ty))
 }
 
-pub(crate) unsafe fn controlled_gate(module: LLVMModuleRef, name: &str) -> (LLVMTypeRef, LLVMValueRef) {
+pub(crate) unsafe fn controlled_gate(
+    module: LLVMModuleRef,
+    name: &str,
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let qubit = types::qubit(context);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [qubit, qubit]);
     (ty, declare_qis(module, name, Functor::Body, ty))
 }
 
-pub(crate) unsafe fn doubly_controlled_gate(module: LLVMModuleRef, name: &str) -> (LLVMTypeRef, LLVMValueRef) {
+pub(crate) unsafe fn doubly_controlled_gate(
+    module: LLVMModuleRef,
+    name: &str,
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let qubit = types::qubit(context);
     let ty = function_type(LLVMVoidTypeInContext(context), &mut [qubit, qubit, qubit]);
     (ty, declare_qis(module, name, Functor::Body, ty))
 }
 
-pub(crate) unsafe fn rotation_gate(module: LLVMModuleRef, name: &str) -> (LLVMTypeRef, LLVMValueRef) {
+pub(crate) unsafe fn rotation_gate(
+    module: LLVMModuleRef,
+    name: &str,
+) -> (LLVMTypeRef, LLVMValueRef) {
     let context = LLVMGetModuleContext(module);
     let ty = function_type(
         LLVMVoidTypeInContext(context),

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -168,8 +168,9 @@ pub unsafe fn global_string(module: LLVMModuleRef, value: &[u8]) -> LLVMValueRef
         0,
     );
 
-    let len = LLVMGetArrayLength(LLVMTypeOf(string));
-    let ty = LLVMArrayType(LLVMInt8TypeInContext(context), len);
+    let len = LLVMGetArrayLength2(LLVMTypeOf(string));
+    let i8_ty = LLVMInt8TypeInContext(context);
+    let ty = LLVMArrayType2(i8_ty, len);
     let global = LLVMAddGlobal(module, ty, raw_cstr!(""));
     LLVMSetLinkage(global, LLVMLinkage::LLVMInternalLinkage);
     LLVMSetGlobalConstant(global, 1);
@@ -177,8 +178,8 @@ pub unsafe fn global_string(module: LLVMModuleRef, value: &[u8]) -> LLVMValueRef
 
     let zero = LLVMConstNull(LLVMInt32TypeInContext(context));
     let mut indices = [zero, zero];
-    #[allow(deprecated)]
-    LLVMConstGEP(
+    LLVMConstGEP2(
+        i8_ty,
         global,
         indices.as_mut_ptr(),
         indices.len().try_into().unwrap(),


### PR DESCRIPTION
Rough work on upgrading to LLVM 18.1.6 (#224). This builds, but the tests definitely do not pass (some segfault, actually). So this should **not** be merged into `main` in its current state, but I'm putting this up if it saves someone some time.

I built this with the following in `pyqir/`:
```
$ pip install -v --config-settings=build-args='-F qirlib/llvm18-1 -F pyqir/llvm18-1' .[test]
```
(I did not use the PowerShell build script.)

### Remaining Problems
If y'all are interested, I can continue working on this and get the tests to pass.

One thing that seems particularly nasty at the moment is how to handle `Builder.call()`. I can think of two options:
1. Modify the signature of `Builder.call()` to also take a `Type` (looks like that already exists in `types.rs`). This is backwards incompatible
2. Modify `Value` to also hold an `LLVMType`. (This may quickly become burdensome to support in future usecases, but it would probably be a simpler user-facing API)

What do y'all think? And are there plans to upgrade LLVM at all?