### PR TITLE
Fix commands related to maturin in building docs

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -26,7 +26,7 @@ Install python and libs:
 ```bash
 sudo apt-get install -y --no-install-recommends python3-dev python3-pip
 python3 -m pip install --user -U pip
-python3 -m pip install --user maturin
+python3 -m pip install --user maturin~=1.4.0
 ```
 
 Install Rust from [rustup](https://rustup.rs/).
@@ -42,7 +42,7 @@ path.
 In a command prompt:
 
 ```bash
-python -m pip install --user maturin
+python -m pip install --user maturin~=1.4.0
 ```
 
 Install Rust from [rustup](https://rustup.rs/).
@@ -55,7 +55,7 @@ or brew:
 
 ```bash
 brew install 'python@3.9'
-python -m pip install --user maturin
+python -m pip install --user maturin~=1.4.0
 ```
 
 Install Rust from [rustup](https://rustup.rs/).
@@ -104,18 +104,17 @@ The [](#environment-variables) section details ways to change this behavior.
 
 Within each project folder, the build can be run specifically for that project.
 
-For any of these commands, the LLVM version must be added via features. For `maturin`,
-they must be added to the `cargo-extra-args` option.
+For any of these commands, the LLVM version must be added via features.
 
 - `<features>` is a placeholder for `--features (llvm11-0 | llvm12-0 | llvm13-0 | llvm14-0)`
 
 Build commands:
 
-- `maturin build --cargo-extra-args="<features>"`: Build the crate into python packages
-- `maturin build --release --cargo-extra-args="<features>"`: Build and pass --release to cargo
+- `maturin build <features>`: Build the crate into python packages
+- `maturin build --release <features>`: Build and pass --release to cargo
 - `maturin build --help`: to view more options
-- `maturin develop --cargo-extra-args="<features>"`: Installs the crate as module in the current virtualenv
-- `maturin develop --cargo-extra-args="<features>" && pytest`: Installs the crate as module in the current
+- `maturin develop <features>`: Installs the crate as module in the current virtualenv
+- `maturin develop <features> && pytest`: Installs the crate as module in the current
   virtualenv and runs the Python tests
 
 If you do not wish to package and test the Python wheels, `cargo` can be used to


### PR DESCRIPTION
This PR fixes two things in the building docs : 
- Documentation suggests to install latest `maturin` version, but the version pinned in pyproject.toml is `~=1.4.0`, resulting in this warning :
  ```
  ⚠️  Warning: You specified maturin ~=1.4.0 in pyproject.toml under `build-system.requires`, but the current maturin version is 1.7.6
  ```
- Build commands in docs use `--cargo-extra-args` option but it is [removed since version `O.13`](url) :
  ```
  ❯ maturin build --cargo-extra-args="--features llvm14-0"
  error: unexpected argument '--cargo-extra-args' found
  
    tip: a similar argument exists: '--target'
  
  Usage: maturin build <--quiet|--jobs <N>|--profile <PROFILE-NAME>|--features <FEATURES>|--all-features|--no-default-features|--target <TRIPLE>|--target-dir <DIRECTORY>|--manifest-path <PATH>|--ignore-rust-version|--verbose...|--color <WHEN>|--frozen|--locked|--offline|--config <KEY=VALUE>|-Z <FLAG>|--timings=<FMTS>|--future-incompat-report|ARGS>
  
  For more information, try '--help'.
  ```