### PR TITLE
Add support for "mz" to passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "pyqir"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "const-str",
  "llvm-sys 110.0.4",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "qirlib"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "bitvec",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Microsoft"]
-version = "0.10.8"
+version = "0.10.9"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/qir-alliance/pyqir"

--- a/pyqir/NOTICE-WHEEL.txt
+++ b/pyqir/NOTICE-WHEEL.txt
@@ -5595,7 +5595,7 @@ limitations under the License.
 
 
 
-qirlib 0.10.8 - SPDX: MIT - MIT License
+qirlib 0.10.9 - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 /*
@@ -5970,7 +5970,7 @@ SOFTWARE.
 
 
 
-pyqir 0.10.8 - SPDX: MIT - MIT License
+pyqir 0.10.9 - SPDX: MIT - MIT License
 https://github.com/qir-alliance/pyqir
 
 MIT License

--- a/pyqir/pyproject.toml
+++ b/pyqir/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyqir"
-version = "0.10.8"
+version = "0.10.9"
 requires-python = ">= 3.8"
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/pyqir/pyqir/_passes.py
+++ b/pyqir/pyqir/_passes.py
@@ -177,6 +177,8 @@ class QirModuleVisitor:
             self._on_qis_z(call, call.args[0])
         elif callee_name == "__quantum__qis__m__body":
             self._on_qis_m(call, call.args[0], call.args[1])
+        elif callee_name == "__quantum__qis__mz__body":
+            self._on_qis_mz(call, call.args[0], call.args[1])
         elif callee_name == "__quantum__qis__mresetz__body":
             self._on_qis_mresetz(call, call.args[0], call.args[1])
         elif callee_name == "__quantum__qis__reset__body":
@@ -323,6 +325,12 @@ class QirModuleVisitor:
     def _on_qis_m(self, call: Call, target: Value, result: Value) -> None:
         """
         Invoked for each call instruction to non-destructive measurement M in a basic block.
+        """
+        pass
+
+    def _on_qis_mz(self, call: Call, target: Value, result: Value) -> None:
+        """
+        Invoked for each call instruction to non-destructive measurement Mz in a basic block.
         """
         pass
 

--- a/pyqir/tests/resources/test_passes_distinguish_m.ll
+++ b/pyqir/tests/resources/test_passes_distinguish_m.ll
@@ -1,0 +1,35 @@
+; ModuleID = 'random_bit'
+%Result = type opaque
+%Qubit = type opaque
+
+define void @random_bit() #0 {
+block_0:
+  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))  
+  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+  ret void
+}
+
+declare void @__quantum__qis__h__body(%Qubit*)
+
+declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+
+declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) #1
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="3" }
+attributes #1 = { "irreversible" }
+
+; module flags
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}

--- a/pyqir/tests/test_passes.py
+++ b/pyqir/tests/test_passes.py
@@ -103,3 +103,29 @@ def test_multtiple_blocks_traversed_in_order() -> None:
         "else",
         "continue",
     ]
+
+
+def test_distinguishing_m_vs_mz() -> None:
+    ir = read_file("resources/test_passes_distinguish_m.ll")
+    module = pyqir.Module.from_ir(pyqir.Context(), ir)
+
+    class CountMeas(pyqir.QirModuleVisitor):
+        def __init__(self) -> None:
+            self.m_count = 0
+            self.mz_count = 0
+            super().__init__()
+
+        def _on_qis_m(
+            self, call: pyqir.Call, target: pyqir.Value, result: pyqir.Value
+        ) -> None:
+            self.m_count += 1
+
+        def _on_qis_mz(
+            self, call: pyqir.Call, target: pyqir.Value, result: pyqir.Value
+        ) -> None:
+            self.mz_count += 1
+
+    visitor = CountMeas()
+    visitor.run(module)
+    assert visitor.m_count == 2
+    assert visitor.mz_count == 1


### PR DESCRIPTION
This updates the `QirModuleVisitor` to include built-in support for `__quantum__qis__mz__body` and differentiates it from `__quantum__qis__m__body`.