### PR TITLE
Add workflow dispatch for CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This makes it easier to check status of current CI builds without openning a PR.