### PR TITLE
Fix condition affecting cached build

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -194,7 +194,7 @@ extends:
 
           - pwsh: ./build.ps1 -t install-llvm-from-source
             displayName: Build and Install LLVM
-            # condition: and(succeeded(), not(canceled()), not(failed()), ne(variables.CACHE_RESTORED, 'true'), ne(variables['Agent.OS'], 'Darwin'))
+            condition: and(succeeded(), not(canceled()), not(failed()), ne(variables.CACHE_RESTORED, 'true'))
 
           # On macOS, we use ARCHFLAGS to ensure that
           # LLVM is built for the correct architecture.


### PR DESCRIPTION
Previous PR incorrectly commented out a whole condition when only part of the condition needed to be removed.