### PR TITLE
Add qirlib feature flag to skip llvm_wrapper

### DIFF
--- a/qirlib/Cargo.toml
+++ b/qirlib/Cargo.toml
@@ -26,6 +26,7 @@ cc = "1.0"
 name = "qirlib"
 
 [features]
+no-module-metadata = []
 llvm18-1 = ["llvm-sys-181"]
 llvm19-1 = ["llvm-sys-191"]
 llvm20-1 = ["llvm-sys-201"]

--- a/qirlib/build.rs
+++ b/qirlib/build.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     } else {
         println!("No LLVM linking");
     }
-    if !cfg!(feature = "no-llvm-linking") {
+    if !cfg!(feature = "no-llvm-linking") && !cfg!(feature = "no-module-metadata") {
         compile_llvm_wrapper()?;
     }
 

--- a/qirlib/src/lib.rs
+++ b/qirlib/src/lib.rs
@@ -20,10 +20,13 @@ pub mod builder;
 #[cfg(not(feature = "no-llvm-linking"))]
 pub mod context;
 #[cfg(not(feature = "no-llvm-linking"))]
+#[cfg(not(feature = "no-module-metadata"))]
 pub(crate) mod llvm_wrapper;
 #[cfg(not(feature = "no-llvm-linking"))]
+#[cfg(not(feature = "no-module-metadata"))]
 pub mod metadata;
 #[cfg(not(feature = "no-llvm-linking"))]
+#[cfg(not(feature = "no-module-metadata"))]
 pub mod module;
 #[cfg(not(feature = "no-llvm-linking"))]
 pub mod qis;


### PR DESCRIPTION
This adds a flag to qirlib to allow Rust code building against it to skip building and linking the llvm_wrapper C++ code when that consumer doesn't need module metadata APIs.