### PR TITLE
Use `LLVMIsAConstantAggregateZero` to check for empty or zero init strings

### DIFF
--- a/pyqir/tests/test_parser.py
+++ b/pyqir/tests/test_parser.py
@@ -151,6 +151,23 @@ def test_null_i8ptr_string() -> None:
     assert string is None
 
 
+def test_zeroinit_string() -> None:
+    llvm_ir = """
+    @.str = private constant [1 x i8] zeroinitializer
+
+    define void @main() {
+      call void @a(ptr @.str)
+      ret void
+    }
+    declare void @a(ptr)
+    """
+
+    module = Module.from_ir(Context(), llvm_ir, "module")
+    zeroinit_value = module.functions[0].basic_blocks[0].instructions[0].operands[0]
+    string = extract_byte_string(zeroinit_value)
+    assert string is None
+
+
 def test_parser_zext_support() -> None:
     bitcode = Path("tests/select.bc").read_bytes()
     mod = Module.from_bitcode(Context(), bitcode)

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -213,6 +213,9 @@ pub unsafe fn extract_string(value: LLVMValueRef) -> Option<Vec<u8>> {
     let element = LLVMGetOperand(value, 0);
     let mut len = 0;
     let data = LLVMGetAsString(element, &raw mut len);
+    if data.is_null() {
+        return None;
+    }
     let data = slice::from_raw_parts(data.cast(), len);
     Some(data[..].to_vec())
 }

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -211,12 +211,9 @@ pub unsafe fn extract_string(value: LLVMValueRef) -> Option<Vec<u8>> {
     }
 
     let element = LLVMGetOperand(value, 0);
-    if LLVMIsConstantString(element) == 0 {
-        return None;
-    }
     let mut len = 0;
     let data = LLVMGetAsString(element, &raw mut len);
-    if data.is_null() {
+    if data.is_null() || len == 0 {
         return None;
     }
     let data = slice::from_raw_parts(data.cast(), len);

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -211,6 +211,9 @@ pub unsafe fn extract_string(value: LLVMValueRef) -> Option<Vec<u8>> {
     }
 
     let element = LLVMGetOperand(value, 0);
+    if LLVMIsConstantString(element) == 0 {
+        return None;
+    }
     let mut len = 0;
     let data = LLVMGetAsString(element, &raw mut len);
     if data.is_null() {

--- a/qirlib/src/values.rs
+++ b/qirlib/src/values.rs
@@ -211,11 +211,11 @@ pub unsafe fn extract_string(value: LLVMValueRef) -> Option<Vec<u8>> {
     }
 
     let element = LLVMGetOperand(value, 0);
-    let mut len = 0;
-    let data = LLVMGetAsString(element, &raw mut len);
-    if data.is_null() || len == 0 {
+    if LLVMIsAConstantAggregateZero(element) == element {
         return None;
     }
+    let mut len = 0;
+    let data = LLVMGetAsString(element, &raw mut len);
     let data = slice::from_raw_parts(data.cast(), len);
     Some(data[..].to_vec())
 }


### PR DESCRIPTION
Fixes #347