### PR TITLE
Enable private members in autodoc options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
 autodoc_default_options = {
     "members": None,
     "undoc-members": True,
+    "private-members": True,
     "show-inheritance": True,
 }
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}


### PR DESCRIPTION
...so that the hooks in `QirModuleVisitor` (e.g. `_on_function`) are included.